### PR TITLE
Anthropic: Fix tool calls 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -270,9 +270,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.21.1.tgz",
-      "integrity": "sha512-fqdt74RTdplnaFOYhwNjjK/Ec09Dqv9ekYr7PuC6GdhV1RWkziqbpJBewn42CYYqCr92JeX6g+IXVgXmq9l7XQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.22.0.tgz",
+      "integrity": "sha512-dv4BCC6FZJw3w66WNLsHlUFjhu19fS1L/5jMPApwhZLa/Oy1j0A2i3RypmDtHEPp4Wwg3aZkSHksp7VzYWjzmw==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -31313,7 +31313,7 @@
       "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.21.0",
+        "@anthropic-ai/sdk": "^0.22.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {

--- a/plugins/anthropic/package.json
+++ b/plugins/anthropic/package.json
@@ -25,7 +25,7 @@
   "author": "TheFireCo",
   "license": "Apache-2.0",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.21.0",
+    "@anthropic-ai/sdk": "^0.22.0",
     "zod": "^3.23.8"
   },
   "peerDependencies": {


### PR DESCRIPTION
Update anthropic sdk; tools are GA in the latest release.

_Before you submit a pull request, please make sure you have read and understood the [contribution guidelines](https://github.com/TheFireCo/genkit-plugins/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/TheFireCo/genkit-plugins/blob/main/CODE_OF_CONDUCT.md)._

**This pull request is related to:**

- [X] A bug
- [ ] A new feature
- [ ] Documentation
- [X] Other (please specify)

**I have checked the following:**

- [X] I have read and understood the [contribution guidelines](https://github.com/TheFireCo/genkit-plugins/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/TheFireCo/genkit-plugins/blob/main/CODE_OF_CONDUCT.md);
- [X] I have added new tests (for bug fixes/features);
- [X] I have added/updated the documentation (for bug fixes / features).

**Description:**

I've been working on testing tool calling with all of the 3P models, and ran into some issues with Anthropic. Particularly, Anthropic will combine text and tool parts together into a single message. It does this to provide chain of thought reasoning for debug purposes. It's also possible to get a batch of tool requests. However, the current plugin will turn these parts into multiple candidates.

Changes
- Upgrade: Anthropic SDK to `0.22.0` which supports tools in GA
- Fix: Return a single response candidate with multiple parts
- Fix: Properly convert "stop" reasons
- Fix: Support complex objects in tool results
- Fix: Improve testability of anthropic response conversion
- Cleanup: Rename `choice` -> `event` _(I think choice was copied over from OpenAI)_

There's some overlap with #72 wrt Schema config. We should probably merge that one first, and resolve any conflicts here.

![image](https://github.com/TheFireCo/genkit-plugins/assets/2858322/ae56bc85-4167-4718-822b-f25c0d9f4635)

**Related issues:**
N/A