### PR TITLE
Enable SonarCloud scan only if `SONAR_TOKEN` secret exists

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
     - run: npm run build
     - run: npm run test
     - name: SonarCloud Scan
+      if: ${{ secrets.SONAR_TOKEN }}
       uses: SonarSource/sonarcloud-github-action@v2
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     - run: npm run build
     - run: npm run test
     - name: SonarCloud Scan
-      if: ${{ secrets.SONAR_TOKEN }}
+      if: env.SONAR_TOKEN != null
       uses: SonarSource/sonarcloud-github-action@v2
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
_Before you submit a pull request, please make sure you have read and understood the [contribution guidelines](https://github.com/TheFireCo/genkit-plugins/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/TheFireCo/genkit-plugins/blob/main/CODE_OF_CONDUCT.md)._

**This pull request is related to:**

- [ ] A bug
- [ ] A new feature
- [ ] Documentation
- [x] Other (please specify) An improvement to the CI

**I have checked the following:**

- [x] I have read and understood the [contribution guidelines](https://github.com/TheFireCo/genkit-plugins/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/TheFireCo/genkit-plugins/blob/main/CODE_OF_CONDUCT.md);
- [ ] I have added new tests (for bug fixes/features);
- [ ] I have added/updated the documentation (for bug fixes / features).

**Description:**
This PR runs the SonarCloud Scan step only if the `SONAR_TOKEN` variable exists. In this way, CI from forks of the repo won't fail if they don't specify it.

**Related issues:**
N/A
