### PR TITLE
fix: only parse arguments when a tool is called

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -44,6 +44,17 @@
       ]
     },
     {
+      "login": "xavidop",
+      "name": "Xavier Portilla Edo",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4416096?v=4",
+      "profile": "https://xavidop.me",
+      "contributions": [
+        "code",
+        "doc",
+        "test"
+      ]
+    },
+    {
       "login": "TommasoBendinelli",
       "name": "Tommaso Bendinelli",
       "avatar_url": "https://avatars.githubusercontent.com/u/43389342?v=4",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -44,17 +44,6 @@
       ]
     },
     {
-      "login": "xavidop",
-      "name": "Xavier Portilla Edo",
-      "avatar_url": "https://avatars.githubusercontent.com/u/4416096?v=4",
-      "profile": "https://xavidop.me",
-      "contributions": [
-        "code",
-        "doc",
-        "test"
-      ]
-    },
-    {
       "login": "TommasoBendinelli",
       "name": "Tommaso Bendinelli",
       "avatar_url": "https://avatars.githubusercontent.com/u/43389342?v=4",

--- a/plugins/openai/src/gpt.test.ts
+++ b/plugins/openai/src/gpt.test.ts
@@ -269,7 +269,10 @@ describe('fromOpenAiToolCall', () => {
         arguments: '{"topic":"bob"}',
       },
     };
-    const actualOutput = fromOpenAiToolCall(toolCall);
+    const actualOutput = fromOpenAiToolCall(toolCall, {
+      message: { tool_calls: [toolCall] },
+      finish_reason: 'tool_calls',
+    } as ChatCompletion.Choice);
     expect(actualOutput).toStrictEqual({
       toolRequest: {
         ref: 'call_SVDpFV2l2fW88QRFtv85FWwM',
@@ -288,7 +291,10 @@ describe('fromOpenAiToolCall', () => {
         arguments: '',
       },
     };
-    const actualOutput = fromOpenAiToolCall(toolCall);
+    const actualOutput = fromOpenAiToolCall(toolCall, {
+      message: { tool_calls: [toolCall] },
+      finish_reason: 'tool_calls',
+    } as ChatCompletion.Choice);
     expect(actualOutput).toStrictEqual({
       toolRequest: {
         ref: 'call_SVDpFV2l2fW88QRFtv85FWwM',
@@ -304,7 +310,13 @@ describe('fromOpenAiToolCall', () => {
       type: 'function',
       function: undefined as any,
     };
-    expect(() => fromOpenAiToolCall(toolCall)).toThrowError(
+
+    expect(() =>
+      fromOpenAiToolCall(toolCall, {
+        message: { tool_calls: [toolCall] },
+        finish_reason: 'tool_calls',
+      } as ChatCompletion.Choice)
+    ).toThrowError(
       'Unexpected openAI chunk choice. tool_calls was provided but one or more tool_calls is missing.'
     );
   });


### PR DESCRIPTION
**This pull request is related to:**

- [x] A bug
- [ ] A new feature
- [ ] Documentation
- [ ] Other (please specify)

**I have checked the following:**

- [x] I have read and understood the [contribution guidelines](https://github.com/TheFireCo/genkit-plugins/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/TheFireCo/genkit-plugins/blob/main/CODE_OF_CONDUCT.md);
- [x] I have added new tests (for bug fixes/features);
- [x] I have added/updated the documentation (for bug fixes / features).

**Description:**
This issue fixes a bug when you call a tool in streaming mode. You have to parse only when the tool is being called.

