### PR TITLE
(feat) added support for latest sonnet 3.5 and haiku 3.5

### DIFF
--- a/plugins/anthropic/src/claude.test.ts
+++ b/plugins/anthropic/src/claude.test.ts
@@ -41,7 +41,7 @@ import type { CandidateData, ToolDefinition } from 'genkit/model';
 
 import type { AnthropicConfigSchema } from './claude';
 import {
-  claude3Haiku,
+  claude35Haiku,
   claudeModel,
   claudeRunner,
   fromAnthropicContentBlockChunk,
@@ -678,7 +678,40 @@ describe('toAnthropicRequestBody', () => {
             role: 'user',
           },
         ],
-        model: 'claude-3-5-sonnet-20240620',
+        model: 'claude-3-5-sonnet-latest',
+        metadata: {
+          user_id: 'exampleUser123',
+        },
+      },
+    },
+    {
+      should: '(claude-3-5-haiku) handles request with text messages',
+      modelName: 'claude-3-5-haiku',
+      genkitRequest: {
+        messages: [
+          { role: 'user', content: [{ text: 'Tell a joke about dogs.' }] },
+        ],
+        output: { format: 'text' },
+        config: {
+          metadata: {
+            user_id: 'exampleUser123',
+          },
+        },
+      },
+      expectedOutput: {
+        max_tokens: 4096,
+        messages: [
+          {
+            content: [
+              {
+                text: 'Tell a joke about dogs.',
+                type: 'text',
+              },
+            ],
+            role: 'user',
+          },
+        ],
+        model: 'claude-3-5-haiku-latest',
         metadata: {
           user_id: 'exampleUser123',
         },
@@ -804,7 +837,7 @@ describe('toAnthropicRequestBody', () => {
 
   it('should throw if output format is not text', () => {
     expect(() =>
-      toAnthropicRequestBody('claude-3-haiku', {
+      toAnthropicRequestBody('claude-3-5-haiku', {
         messages: [],
         tools: [],
         output: { format: 'media' },
@@ -825,7 +858,7 @@ describe('toAnthropicRequestBody', () => {
 
     // Test with caching enabled
     const outputWithCaching = toAnthropicRequestBody(
-      'claude-3-haiku',
+      'claude-3-5-haiku',
       request,
       false,
       true
@@ -840,7 +873,7 @@ describe('toAnthropicRequestBody', () => {
 
     // Test with caching disabled
     const outputWithoutCaching = toAnthropicRequestBody(
-      'claude-3-haiku',
+      'claude-3-5-haiku',
       request,
       false,
       false
@@ -863,12 +896,12 @@ describe('claudeRunner', () => {
       },
     };
     const runner = claudeRunner(
-      'claude-3-haiku',
+      'claude-3-5-haiku',
       anthropicClient as unknown as Anthropic
     );
     await runner({ messages: [] });
     expect(anthropicClient.messages.create).toHaveBeenCalledWith({
-      model: 'claude-3-haiku-20240307',
+      model: 'claude-3-5-haiku-latest',
       max_tokens: 4096,
     });
   });
@@ -916,12 +949,12 @@ describe('claudeRunner', () => {
     };
     const streamingCallback = jest.fn();
     const runner = claudeRunner(
-      'claude-3-haiku',
+      'claude-3-5-haiku',
       anthropicClient as unknown as Anthropic
     );
     await runner({ messages: [] }, streamingCallback);
     expect(anthropicClient.messages.stream).toHaveBeenCalledWith({
-      model: 'claude-3-haiku-20240307',
+      model: 'claude-3-5-haiku-latest',
       max_tokens: 4096,
       stream: true,
     });
@@ -943,12 +976,12 @@ describe('claudeModel', () => {
 
   it('should correctly define supported Claude models', () => {
     jest.spyOn(ai, 'defineModel').mockImplementation((() => ({})) as any);
-    claudeModel(ai, 'claude-3-haiku', {} as Anthropic);
+    claudeModel(ai, 'claude-3-5-haiku', {} as Anthropic);
     expect(ai.defineModel).toHaveBeenCalledWith(
       {
-        name: claude3Haiku.name,
-        ...claude3Haiku.info,
-        configSchema: claude3Haiku.configSchema,
+        name: claude35Haiku.name,
+        ...claude35Haiku.info,
+        configSchema: claude35Haiku.configSchema,
       },
       expect.any(Function)
     );

--- a/plugins/anthropic/src/claude.ts
+++ b/plugins/anthropic/src/claude.ts
@@ -73,7 +73,11 @@ export const AnthropicConfigSchema = GenerationCommonConfigSchema.extend({
 export const claude35Sonnet = modelRef({
   name: 'anthropic/claude-3-5-sonnet',
   info: {
-    versions: ['claude-3-5-sonnet-20240620'],
+    versions: [
+      'claude-3-5-sonnet-20240620',
+      'claude-3-5-sonnet-20241022',
+      'claude-3-5-sonnet-latest',
+    ],
     label: 'Anthropic - Claude 3.5 Sonnet',
     supports: {
       multiturn: true,
@@ -84,7 +88,7 @@ export const claude35Sonnet = modelRef({
     },
   },
   configSchema: AnthropicConfigSchema,
-  version: 'claude-3-5-sonnet-20240620',
+  version: 'claude-3-5-sonnet-latest',
 });
 
 export const claude3Opus = modelRef({
@@ -138,6 +142,23 @@ export const claude3Haiku = modelRef({
   version: 'claude-3-haiku-20240307',
 });
 
+export const claude35Haiku = modelRef({
+  name: 'anthropic/claude-3-5-haiku',
+  info: {
+    versions: ['claude-3-5-haiku-20241022', 'claude-3-5-haiku-latest'],
+    label: 'Anthropic - Claude 3.5 Haiku',
+    supports: {
+      multiturn: true,
+      tools: true,
+      media: true,
+      systemRole: true,
+      output: ['text'],
+    },
+  },
+  configSchema: AnthropicConfigSchema,
+  version: 'claude-3-5-haiku-latest',
+});
+
 export const SUPPORTED_CLAUDE_MODELS: Record<
   string,
   ModelReference<typeof AnthropicConfigSchema>
@@ -146,6 +167,7 @@ export const SUPPORTED_CLAUDE_MODELS: Record<
   'claude-3-opus': claude3Opus,
   'claude-3-sonnet': claude3Sonnet,
   'claude-3-haiku': claude3Haiku,
+  'claude-3-5-haiku': claude35Haiku,
 };
 
 /**


### PR DESCRIPTION
**This pull request is related to:**

- [ ] A bug
- [x] A new feature
- [ ] Documentation
- [ ] Other (please specify)

**I have checked the following:**

- [x] I have read and understood the [contribution guidelines](https://github.com/TheFireCo/genkit-plugins/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/TheFireCo/genkit-plugins/blob/main/CODE_OF_CONDUCT.md);
- [x] I have added new tests (for bug fixes/features);
- [x] I have added/updated the documentation (for bug fixes / features).

**Description:**
1. Support added for the October version of Sonnet 3.5 as well as "Latest" version.
2. Support for Haiku 3.5
3. Tests updated accordingly for each

*Defaulting to "Latest" model version*
I updated both Sonnet 3.5 and Haiku 3.5 to default to the "latest" model version. Users can choose to opt out of this by passing the version themselves in the config if they want to: 

```
model: anthropic/claude-3-5-haiku
config:
  version: claude-3-5-haiku-20241022 // <-- user can override "latest" 
```
I believe this is preferable for two reason: 
1. When there are new model releases, users do not have to wait for a new version to be merged here.
2. Users can easily opt out of the latest model instead of opting in to the latest model.

**Related issues:**
Fixes: #154 
