### PR TITLE
fix: if we have only text, we should not use multiparts

### DIFF
--- a/plugins/openai/src/gpt.test.ts
+++ b/plugins/openai/src/gpt.test.ts
@@ -203,9 +203,9 @@ describe('toOpenAiMessages', () => {
         { role: 'user', content: [{ text: 'I am testing' }] },
       ],
       expectedOutput: [
-        { role: 'user', content: [{ text: 'hi', type: 'text' }] },
+        { role: 'user', content: 'hi' },
         { role: 'assistant', content: 'how can I help you?' },
-        { role: 'user', content: [{ text: 'I am testing', type: 'text' }] },
+        { role: 'user', content: 'I am testing' },
       ],
     },
     {
@@ -554,7 +554,7 @@ describe('toOpenAiRequestBody', () => {
         messages: [
           {
             role: 'user',
-            content: [{ type: 'text', text: 'Tell a joke about dogs.' }],
+            content: 'Tell a joke about dogs.',
           },
         ],
         model: 'gpt-3.5-turbo',
@@ -628,7 +628,7 @@ describe('toOpenAiRequestBody', () => {
         messages: [
           {
             role: 'user',
-            content: [{ type: 'text', text: 'Tell a joke about dogs.' }],
+            content: 'Tell a joke about dogs.',
           },
           {
             role: 'assistant',
@@ -725,7 +725,7 @@ describe('toOpenAiRequestBody', () => {
         messages: [
           {
             role: 'user',
-            content: [{ type: 'text', text: 'Tell a joke about dogs.' }],
+            content: 'Tell a joke about dogs.',
           },
           {
             role: 'assistant',
@@ -820,7 +820,7 @@ describe('toOpenAiRequestBody', () => {
         messages: [
           {
             role: 'user',
-            content: [{ type: 'text', text: 'Tell a joke about dogs.' }],
+            content: 'Tell a joke about dogs.',
           },
           {
             role: 'assistant',
@@ -915,7 +915,7 @@ describe('toOpenAiRequestBody', () => {
         messages: [
           {
             role: 'user',
-            content: [{ type: 'text', text: 'Tell a joke about dogs.' }],
+            content: 'Tell a joke about dogs.',
           },
           {
             role: 'assistant',
@@ -1069,7 +1069,7 @@ describe('toOpenAiRequestBody', () => {
       messages: [
         {
           role: 'user',
-          content: [{ type: 'text', text: 'Tell a joke about dogs.' }],
+          content: 'Tell a joke about dogs.',
         },
         {
           role: 'assistant',
@@ -1221,7 +1221,7 @@ describe('toOpenAiRequestBody', () => {
       messages: [
         {
           role: 'user',
-          content: [{ type: 'text', text: 'Tell a joke about dogs.' }],
+          content: 'Tell a joke about dogs.',
         },
         {
           role: 'assistant',

--- a/plugins/openai/src/gpt.ts
+++ b/plugins/openai/src/gpt.ts
@@ -353,12 +353,28 @@ export function toOpenAiMessages(
     const role = toOpenAIRole(message.role);
     switch (role) {
       case 'user':
-        openAiMsgs.push({
-          role: role,
-          content: msg.content.map((part) =>
-            toOpenAiTextAndMedia(part, visualDetailLevel)
-          ),
-        });
+        const content = msg.content.map((part) =>
+          toOpenAiTextAndMedia(part, visualDetailLevel)
+        );
+        // Check if we have only text content
+        const onlyTextContent = content.some((item) => item.type !== 'text');
+
+        // If all items are strings, just add them as text
+        if (!onlyTextContent) {
+          content.forEach((item, index) => {
+            if (item.type === 'text') {
+              openAiMsgs.push({
+                role: role,
+                content: item.text,
+              });
+            }
+          });
+        } else {
+          openAiMsgs.push({
+            role: role,
+            content: content,
+          });
+        }
         break;
       case 'system':
         openAiMsgs.push({

--- a/plugins/openai/src/index.ts
+++ b/plugins/openai/src/index.ts
@@ -124,9 +124,12 @@ export const openAI = (options?: PluginOptions) =>
       gptModel(ai, name, client);
     }
     // Initialize the models if provided in the options
-    options?.models?.map((model) =>
-      gptModel(ai, model.name, client, model.info, model.configSchema)
-    );
+    options?.models?.map((model) => {
+      if (!model.name || !model.info || !model.configSchema) {
+        throw new Error(`Model ${model.name} is missing required fields`);
+      }
+      gptModel(ai, model.name, client, model.info, model.configSchema);
+    });
 
     dallE3Model(ai, client);
     whisper1Model(ai, client);


### PR DESCRIPTION
_Before you submit a pull request, please make sure you have read and understood the [contribution guidelines](https://github.com/TheFireCo/genkit-plugins/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/TheFireCo/genkit-plugins/blob/main/CODE_OF_CONDUCT.md)._

**This pull request is related to:**

- [x] A bug
- [ ] A new feature
- [ ] Documentation
- [ ] Other (please specify)

**I have checked the following:**

- [x] I have read and understood the [contribution guidelines](https://github.com/TheFireCo/genkit-plugins/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/TheFireCo/genkit-plugins/blob/main/CODE_OF_CONDUCT.md);
- [x] I have added new tests (for bug fixes/features);
- [x] I have added/updated the documentation (for bug fixes / features).

**Description:**
this PR fixes 2 bugs:
1. If a custom model has a missing property, throw an error
2. If all messages are of type text, just set the content value to the text itself instead of `{type: 'text', text: 'myText'}`. that is only required when we are sending text + image
