### PR TITLE
Fix package.json exports field order - move default condition to last position

### DIFF
--- a/plugins/anthropic/package.json
+++ b/plugins/anthropic/package.json
@@ -43,9 +43,9 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "default": "./lib/index.js",
       "import": "./lib/index.mjs",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
     }
   },
   "files": [

--- a/plugins/azure-openai/package.json
+++ b/plugins/azure-openai/package.json
@@ -40,9 +40,9 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "default": "./lib/index.js",
       "import": "./lib/index.mjs",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
     }
   },
   "files": [

--- a/plugins/cohere/package.json
+++ b/plugins/cohere/package.json
@@ -38,9 +38,9 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "default": "./lib/index.js",
       "import": "./lib/index.mjs",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
     }
   },
   "files": [

--- a/plugins/graph/package.json
+++ b/plugins/graph/package.json
@@ -39,9 +39,9 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "default": "./lib/index.js",
       "import": "./lib/index.mjs",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
     }
   },
   "files": [

--- a/plugins/groq/package.json
+++ b/plugins/groq/package.json
@@ -43,9 +43,9 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "default": "./lib/index.js",
       "import": "./lib/index.mjs",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
     }
   },
   "files": [

--- a/plugins/hnsw/package.json
+++ b/plugins/hnsw/package.json
@@ -52,9 +52,9 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "default": "./lib/index.js",
       "import": "./lib/index.mjs",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
     }
   },
   "files": [

--- a/plugins/mistral/package.json
+++ b/plugins/mistral/package.json
@@ -36,9 +36,9 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "default": "./lib/index.js",
       "import": "./lib/index.mjs",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
     }
   },
   "files": [

--- a/plugins/openai/package.json
+++ b/plugins/openai/package.json
@@ -42,9 +42,9 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "default": "./lib/index.js",
       "import": "./lib/index.mjs",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
**This pull request is related to:**
- [x] A bug
- [ ] A new feature
- [ ] Documentation
- [ ] Other (please specify)

**I have checked the following:**
- [x] I have read and understood the [[contribution guidelines](https://github.com/TheFireCo/genkit-plugins/blob/main/CONTRIBUTING.md)](https://github.com/TheFireCo/genkit-plugins/blob/main/CONTRIBUTING.md) and the [[code of conduct](https://github.com/TheFireCo/genkit-plugins/blob/main/CODE_OF_CONDUCT.md)](https://github.com/TheFireCo/genkit-plugins/blob/main/CODE_OF_CONDUCT.md);
- [ ] I have added new tests (for bug fixes/features);
- [x] I have added/updated the documentation (for bug fixes / features).

**Description:**
This PR fixes an issue with the package.json `exports` field configuration by rearranging the order of conditions to move the "default" condition to the last position. The current order causes build failures in NextJS projects with the error message "Module not found: Default condition should be last one". 

The change follows the Node.js module resolution algorithm which expects the "default" condition to be the final fallback option. This simple reordering improves compatibility with build systems like NextJS that strictly adhere to this standard.

Current configuration:
```json
"exports": {
  ".": {
    "require": "./lib/index.js",
    "default": "./lib/index.js",
    "import": "./lib/index.mjs",
    "types": "./lib/index.d.ts"
  }
}
```

Fixed configuration:
```json
"exports": {
  ".": {
    "require": "./lib/index.js",
    "import": "./lib/index.mjs",
    "types": "./lib/index.d.ts",
    "default": "./lib/index.js"
  }
}
```

**Related issues:**
No specific issues linked, but this resolves build failures in NextJS projects that import this package.