### PR TITLE
Add support for GPT-4.1 models including mini and nano variants

### DIFF
--- a/plugins/openai/src/gpt.test.ts
+++ b/plugins/openai/src/gpt.test.ts
@@ -1379,4 +1379,56 @@ describe('gptModel', () => {
       expect.any(Function)
     );
   });
+
+  it('should correctly define gpt-4.1, gpt-4.1-mini, and gpt-4.1-nano', () => {
+    jest.spyOn(ai, 'defineModel').mockImplementation((() => ({})) as any);
+    gptModel(ai, 'gpt-4.1', {} as OpenAI);
+    expect(ai.defineModel).toHaveBeenCalledWith(
+      {
+        name: 'openai/gpt-4.1',
+        ...require('./gpt').gpt41.info,
+        configSchema: require('./gpt').gpt41.configSchema,
+      },
+      expect.any(Function)
+    );
+    gptModel(ai, 'gpt-4.1-mini', {} as OpenAI);
+    expect(ai.defineModel).toHaveBeenCalledWith(
+      {
+        name: 'openai/gpt-4.1-mini',
+        ...require('./gpt').gpt41Mini.info,
+        configSchema: require('./gpt').gpt41Mini.configSchema,
+      },
+      expect.any(Function)
+    );
+    gptModel(ai, 'gpt-4.1-nano', {} as OpenAI);
+    expect(ai.defineModel).toHaveBeenCalledWith(
+      {
+        name: 'openai/gpt-4.1-nano',
+        ...require('./gpt').gpt41Nano.info,
+        configSchema: require('./gpt').gpt41Nano.configSchema,
+      },
+      expect.any(Function)
+    );
+  });
+});
+
+// Additional test to ensure toOpenAiRequestBody works for new models
+
+describe('toOpenAiRequestBody for new GPT-4.1 variants', () => {
+  const baseRequest = { messages: [] } as GenerateRequest<
+    typeof OpenAiConfigSchema
+  >;
+  it('should not throw for gpt-4.1', () => {
+    expect(() => toOpenAiRequestBody('gpt-4.1', baseRequest)).not.toThrow();
+  });
+  it('should not throw for gpt-4.1-mini', () => {
+    expect(() =>
+      toOpenAiRequestBody('gpt-4.1-mini', baseRequest)
+    ).not.toThrow();
+  });
+  it('should not throw for gpt-4.1-nano', () => {
+    expect(() =>
+      toOpenAiRequestBody('gpt-4.1-nano', baseRequest)
+    ).not.toThrow();
+  });
 });

--- a/plugins/openai/src/gpt.ts
+++ b/plugins/openai/src/gpt.ts
@@ -244,6 +244,54 @@ export const gpt4 = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
+export const gpt41 = modelRef({
+  name: 'openai/gpt-4.1',
+  info: {
+    versions: ['gpt-4.1'],
+    label: 'OpenAI - GPT-4.1',
+    supports: {
+      multiturn: true,
+      tools: true,
+      media: false,
+      systemRole: true,
+      output: ['text', 'json'],
+    },
+  },
+  configSchema: OpenAiConfigSchema,
+});
+
+export const gpt41Mini = modelRef({
+  name: 'openai/gpt-4.1-mini',
+  info: {
+    versions: ['gpt-4.1-mini'],
+    label: 'OpenAI - GPT-4.1 Mini',
+    supports: {
+      multiturn: true,
+      tools: true,
+      media: false,
+      systemRole: true,
+      output: ['text', 'json'],
+    },
+  },
+  configSchema: OpenAiConfigSchema,
+});
+
+export const gpt41Nano = modelRef({
+  name: 'openai/gpt-4.1-nano',
+  info: {
+    versions: ['gpt-4.1-nano'],
+    label: 'OpenAI - GPT-4.1 Nano',
+    supports: {
+      multiturn: true,
+      tools: true,
+      media: false,
+      systemRole: true,
+      output: ['text', 'json'],
+    },
+  },
+  configSchema: OpenAiConfigSchema,
+});
+
 export const gpt35Turbo = modelRef({
   name: 'openai/gpt-3.5-turbo',
   info: {
@@ -270,6 +318,9 @@ export const SUPPORTED_GPT_MODELS: Record<
   'gpt-4-turbo': gpt4Turbo,
   'gpt-4-vision': gpt4Vision,
   'gpt-4': gpt4,
+  'gpt-4.1': gpt41,
+  'gpt-4.1-mini': gpt41Mini,
+  'gpt-4.1-nano': gpt41Nano,
   'gpt-3.5-turbo': gpt35Turbo,
   'o1-preview': o1Preview,
   o1: o1,

--- a/plugins/openai/src/index.ts
+++ b/plugins/openai/src/index.ts
@@ -15,8 +15,9 @@
  */
 import type { Genkit } from 'genkit';
 import { genkitPlugin } from 'genkit/plugin';
-import { OpenAI, ClientOptions } from 'openai';
+import { ClientOptions, OpenAI } from 'openai';
 
+import { ModelInfo } from 'genkit/model';
 import { dallE3, dallE3Model } from './dalle.js';
 import {
   openaiEmbedder,
@@ -27,41 +28,46 @@ import {
 } from './embedder.js';
 import {
   gpt35Turbo,
-  gpt45,
   gpt4,
-  gpt4Turbo,
-  gpt4Vision,
+  gpt41,
+  gpt41Mini,
+  gpt41Nano,
+  gpt45,
   gpt4o,
   gpt4oMini,
+  gpt4Turbo,
+  gpt4Vision,
   gptModel,
   o1,
-  o1Preview,
   o1Mini,
+  o1Preview,
   o3Mini,
   SUPPORTED_GPT_MODELS,
 } from './gpt.js';
-import { SUPPORTED_TTS_MODELS, ttsModel, tts1, tts1Hd } from './tts.js';
+import { SUPPORTED_TTS_MODELS, tts1, tts1Hd, ttsModel } from './tts.js';
 import { whisper1, whisper1Model } from './whisper.js';
-import { ModelInfo } from 'genkit/model';
 export {
   dallE3,
   gpt35Turbo,
-  gpt45,
   gpt4,
-  gpt4Turbo,
-  gpt4Vision,
+  gpt41,
+  gpt41Mini,
+  gpt41Nano,
+  gpt45,
   gpt4o,
   gpt4oMini,
+  gpt4Turbo,
+  gpt4Vision,
   o1,
-  o1Preview,
   o1Mini,
+  o1Preview,
   o3Mini,
-  tts1,
-  tts1Hd,
-  whisper1,
   textEmbedding3Large,
   textEmbedding3Small,
   textEmbeddingAda002,
+  tts1,
+  tts1Hd,
+  whisper1,
 };
 
 export interface PluginOptions extends Partial<ClientOptions> {


### PR DESCRIPTION
Before you submit a pull request, please make sure you have read and understood the [contribution guidelines](https://github.com/TheFireCo/genkit-plugins/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/TheFireCo/genkit-plugins/blob/main/CODE_OF_CONDUCT.md).

This pull request is related to:

[ ] A bug
[x] A new feature
[ ] Documentation
[ ] Other (please specify)
I have checked the following:

[x] I have read and understood the [contribution guidelines](https://github.com/TheFireCo/genkit-plugins/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/TheFireCo/genkit-plugins/blob/main/CODE_OF_CONDUCT.md);
[x] I have added new tests (for bug fixes/features);
[ ] I have added/updated the documentation (for bug fixes / features).
Description: This pull request adds support for the following new OpenAI models in the OpenAI plugin:

gpt-4.1
gpt-4.1-mini
gpt-4.1-nano
The new models are defined as modelRefs, added to the SUPPORTED_GPT_MODELS map, and exported for use.
Comprehensive tests were added to ensure these models are recognized and function as expected.
All tests pass, and the test coverage remains high.

Related issues: N/A (This is a small feature PR as per the contribution guidelines. No related issues.)