### PR TITLE
refactor(plugins/openai): migrate plugin to v2 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5605,19 +5605,18 @@
       }
     },
     "node_modules/@genkit-ai/firebase": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/firebase/-/firebase-1.18.0.tgz",
-      "integrity": "sha512-UJVR2Z8839ptPqO+I7WICALlOZdDl4RbYDEaPjK8FpQmyJBjdpToevi6c2MoAXg8wTEd68i1b0cGPKXk9HPTyg==",
-      "license": "Apache-2.0",
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/firebase/-/firebase-1.19.3.tgz",
+      "integrity": "sha512-qDEjnl9qAgPJO9uQvH+ZHuiedgfmtJMtKPpvjn0swYpGpXfhG623uikwfvkHgbwotX8GrnHO0V3vFgopb2dxqg==",
       "optional": true,
       "dependencies": {
-        "@genkit-ai/google-cloud": "^1.18.0"
+        "@genkit-ai/google-cloud": "^1.19.3"
       },
       "peerDependencies": {
         "@google-cloud/firestore": "^7.11.0",
         "firebase": ">=11.5.0",
         "firebase-admin": ">=12.2",
-        "genkit": "^1.18.0"
+        "genkit": "^1.19.3"
       },
       "peerDependenciesMeta": {
         "firebase": {
@@ -5658,10 +5657,9 @@
       }
     },
     "node_modules/@genkit-ai/google-cloud": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/google-cloud/-/google-cloud-1.18.0.tgz",
-      "integrity": "sha512-gVKYmtDl/QiWnOq2qWnzY4SsaP1h1rS2HmHibjM1DHc9qNfBOk1dkGL4shmX7N4R/fcFWFLt7nXQiPJKu6NngQ==",
-      "license": "Apache-2.0",
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/google-cloud/-/google-cloud-1.19.3.tgz",
+      "integrity": "sha512-Vwe9sfm1EuGKZA8CMFezqmOwxXve8pd5NaXXHl1OOUXr3KEAgQJOu/3nR/ZNRbQsC96GPaOF8dejQnWZCRAPZQ==",
       "optional": true,
       "dependencies": {
         "@google-cloud/logging-winston": "^6.0.0",
@@ -5683,14 +5681,13 @@
         "winston": "^3.12.0"
       },
       "peerDependencies": {
-        "genkit": "^1.18.0"
+        "genkit": "^1.19.3"
       }
     },
     "node_modules/@genkit-ai/google-cloud/node_modules/@opentelemetry/core": {
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
       "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.25.1"
@@ -5706,7 +5703,6 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
       "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
@@ -5723,7 +5719,6 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
       "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
@@ -5741,7 +5736,6 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
       "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
@@ -5759,7 +5753,6 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
       "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
-      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -5785,7 +5778,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-5.0.2.tgz",
       "integrity": "sha512-V7bmBKYQyu0eVG2BFejuUjlBt+zrya6vtsKdY+JxMM/dNntPF41vZ9+LhOshEUH01zOHEqBSvI7Dad7ZS6aUeA==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@google-cloud/projectify": "^4.0.0",
@@ -5822,7 +5814,6 @@
       "version": "11.2.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/logging/-/logging-11.2.1.tgz",
       "integrity": "sha512-2h9HBJG3OAsvzXmb81qXmaTPfXYU7KJTQUxunoOKFGnY293YQ/eCkW1Y5mHLocwpEqeqQYT/Qvl6Tk+Q7PfStw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@google-cloud/common": "^5.0.0",
@@ -5850,7 +5841,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/logging-winston/-/logging-winston-6.0.1.tgz",
       "integrity": "sha512-tgA/qe/aGZITMrJ/5Tuykv234pLb/Qo6iDZ8SDkjbsiIy69mLQmbphrUd/IqnE17BSDfrwDUckvWdghiy8b+Qg==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@google-cloud/logging": "^11.0.0",
@@ -5869,7 +5859,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
       "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "is-obj": "^2.0.0"
@@ -5889,7 +5878,6 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -5899,7 +5887,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-monitoring-exporter/-/opentelemetry-cloud-monitoring-exporter-0.19.0.tgz",
       "integrity": "sha512-5SOPXwC6RET4ZvXxw5D97dp8fWpqWEunHrzrUUGXhG4UAeedQe1KvYV8CK+fnaAbN2l2ha6QDYspT6z40TVY0g==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@google-cloud/opentelemetry-resource-util": "^2.3.0",
@@ -5921,7 +5908,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-trace-exporter/-/opentelemetry-cloud-trace-exporter-2.4.1.tgz",
       "integrity": "sha512-Dq2IyAyA9PCjbjLOn86i2byjkYPC59b5ic8k/L4q5bBWH0Jro8lzMs8C0G5pJfqh2druj8HF+oAIAlSdWQ+Z9Q==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@google-cloud/opentelemetry-resource-util": "^2.4.0",
@@ -5943,7 +5929,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-resource-util/-/opentelemetry-resource-util-2.4.0.tgz",
       "integrity": "sha512-/7ujlMoKtDtrbQlJihCjQnm31n2s2RTlvJqcSbt2jV3OkCzPAdo3u31Q13HNugqtIRUSk7bUoLx6AzhURkhW4w==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -5974,7 +5959,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-4.0.0.tgz",
       "integrity": "sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==",
-      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "node": ">=14.0.0"
@@ -8071,7 +8055,6 @@
       "version": "0.49.2",
       "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.49.2.tgz",
       "integrity": "sha512-xtETEPmAby/3MMmedv8Z/873sdLTWg+Vq98rtm4wbwvAiXBB/ao8qRyzRlvR2MR6puEr+vIB/CXeyJnzNA3cyw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -8160,7 +8143,6 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.30.1.tgz",
       "integrity": "sha512-7Ki+x7cZ/PEQxp3UyB+CWkWBqLk22yRGQ4AWIGwZlEs6rpCOdWwIFOyQDO9DdeyWtTPTvO3An/7chPZcRHOgzQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/sdk-trace-base": "1.30.1",
@@ -8178,7 +8160,6 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -8193,7 +8174,6 @@
       "version": "1.28.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
       "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
@@ -8526,7 +8506,6 @@
       "version": "0.41.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.41.0.tgz",
       "integrity": "sha512-00Oi6N20BxJVcqETjgNzCmVKN+I5bJH/61IlHiIWd00snj1FdgiIKlpE4hYVacTB2sjIBB3nTbHskttdZEE2eg==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -8544,7 +8523,6 @@
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.43.0.tgz",
       "integrity": "sha512-pSxcWlsE/pCWQRIw92sV2C+LmKXelYkjkA7C5s39iPUi4pZ2lA1nIiw+1R/y2pDEhUHcaKkNyljQr3cx9ZpVlQ==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -8564,7 +8542,6 @@
       "version": "0.43.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.43.1.tgz",
       "integrity": "sha512-qLT2cCniJ5W+6PFzKbksnoIQuq9pS83nmgaExfUwXVvlwi0ILc50dea0tWBHZMkdIDa/zZdcuFrJ7+fUcSnRow==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -8583,7 +8560,6 @@
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.40.0.tgz",
       "integrity": "sha512-aZ4cXaGWwj79ZXSYrgFVsrDlE4mmf2wfvP9bViwRc0j75A6eN6GaHYHqufFGMTCqASQn5pIjjP+Bx+PWTGiofw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/api-logs": "^0.52.0",
@@ -8601,7 +8577,6 @@
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.40.0.tgz",
       "integrity": "sha512-JxbM39JU7HxE9MTKKwi6y5Z3mokjZB2BjwfqYi4B3Y29YO3I42Z7eopG6qq06yWZc+nQli386UDQe0d9xKmw0A==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -8618,7 +8593,6 @@
       "version": "0.38.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.38.0.tgz",
       "integrity": "sha512-2/nRnx3pjYEmdPIaBwtgtSviTKHWnDZN3R+TkRUnhIVrvBKVcq+I5B2rtd6mr6Fe9cHlZ9Ojcuh7pkNh/xdWWg==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -8637,7 +8611,6 @@
       "version": "3.4.36",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
       "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -8647,7 +8620,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.8.0.tgz",
       "integrity": "sha512-ieTm4RBIlZt2brPwtX5aEZYtYnkyqhAVXJI9RIohiBVMe5DxiwCwt+2Exep/nDVqGPX8zRBZUl4AEw423OxJig==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -8664,7 +8636,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.11.0.tgz",
       "integrity": "sha512-27urJmwkH4KDaMJtEv1uy2S7Apk4XbN4AgWMdfMJbi7DnOduJmeuA+DpJCwXB72tEWXo89z5T3hUVJIDiSNmNw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0"
@@ -8680,7 +8651,6 @@
       "version": "0.38.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.38.0.tgz",
       "integrity": "sha512-Um07I0TQXDWa+ZbEAKDFUxFH40dLtejtExDOMLNJ1CL8VmOmA71qx93Qi/QG4tGkiI1XWqr7gF/oiMCJ4m8buQ==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -8697,7 +8667,6 @@
       "version": "0.41.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.41.1.tgz",
       "integrity": "sha512-uRx0V3LPGzjn2bxAnV8eUsDT82vT7NTwI0ezEuPMBOTOsnPpGhWdhcdNdhH80sM4TrWrOfXm9HGEdfWE3TRIww==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -8715,7 +8684,6 @@
       "version": "0.38.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.38.0.tgz",
       "integrity": "sha512-HBVLpTSYpkQZ87/Df3N0gAw7VzYZV3n28THIBrJWfuqw3Or7UqdhnjeuMIPQ04BKk3aZc0cWn2naSQObbh5vXw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -8733,7 +8701,6 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.14.0.tgz",
       "integrity": "sha512-pVc8P5AgliC1DphyyBUgsxXlm2XaPH4BpYvt7rAZDMIqUpRk8gs19SioABtKqqxvFzg5jPtgJfJsdxq0Y+maLw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -8750,7 +8717,6 @@
       "version": "0.38.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.38.1.tgz",
       "integrity": "sha512-WvssuKCuavu/hlq661u82UWkc248cyI/sT+c2dEIj6yCk0BUkErY1D+9XOO+PmHdJNE+76i2NdcvQX5rJrOe/w==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0"
@@ -8766,7 +8732,6 @@
       "version": "0.42.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.42.0.tgz",
       "integrity": "sha512-N8SOwoKL9KQSX7z3gOaw5UaTeVQcfDO1c21csVHnmnmGUoqsXbArK2B8VuwPWcv6/BC/i3io+xTo7QGRZ/z28Q==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0"
@@ -8782,7 +8747,6 @@
       "version": "0.52.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.52.1.tgz",
       "integrity": "sha512-EdSDiDSAO+XRXk/ZN128qQpBo1I51+Uay/LUPcPQhSRGf7fBPIEUBeOLQiItguGsug5MGOYjql2w/1wCQF3fdQ==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "0.52.1",
@@ -8799,7 +8763,6 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
       "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
-      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -8809,7 +8772,6 @@
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.40.0.tgz",
       "integrity": "sha512-8U/w7Ifumtd2bSN1OLaSwAAFhb9FyqWUki3lMMB0ds+1+HdSxYBe9aspEJEgvxAqOkrQnVniAPTEGf1pGM7SOw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -8827,7 +8789,6 @@
       "version": "0.52.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.52.1.tgz",
       "integrity": "sha512-dG/aevWhaP+7OLv4BQQSEKMJv8GyeOp3Wxl31NHqE8xo9/fYMfEljiZphUHIfyg4gnZ9swMyWjfOQs5GUQe54Q==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
@@ -8846,7 +8807,6 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
       "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.25.1"
@@ -8862,7 +8822,6 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
       "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
-      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -8872,7 +8831,6 @@
       "version": "0.42.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.42.0.tgz",
       "integrity": "sha512-P11H168EKvBB9TUSasNDOGJCSkpT44XgoM6d3gRIWAa9ghLpYhl0uRkS8//MqPzcJVHr3h3RmfXIpiYLjyIZTw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -8890,7 +8848,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.2.0.tgz",
       "integrity": "sha512-uKKmhEFd0zR280tJovuiBG7cfnNZT4kvVTvqtHPxQP7nOmRbJstCYHFH13YzjVcKjkmoArmxiSulmZmF7SLIlg==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -8907,7 +8864,6 @@
       "version": "0.39.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.39.0.tgz",
       "integrity": "sha512-lRwTqIKQecPWDkH1KEcAUcFhCaNssbKSpxf4sxRTAROCwrCEnYkjOuqJHV+q1/CApjMTaKu0Er4LBv/6bDpoxA==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -8924,7 +8880,6 @@
       "version": "0.42.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.42.0.tgz",
       "integrity": "sha512-H1BEmnMhho8o8HuNRq5zEI4+SIHDIglNB7BPKohZyWG4fWNuR7yM4GTlR01Syq21vODAS7z5omblScJD/eZdKw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -8942,7 +8897,6 @@
       "version": "0.39.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.39.0.tgz",
       "integrity": "sha512-eU1Wx1RRTR/2wYXFzH9gcpB8EPmhYlNDIUHzUXjyUE0CAXEJhBLkYNlzdaVCoQDw2neDqS+Woshiia6+emWK9A==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0"
@@ -8958,7 +8912,6 @@
       "version": "0.38.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.38.0.tgz",
       "integrity": "sha512-tPmyqQEZNyrvg6G+iItdlguQEcGzfE+bJkpQifmBXmWBnoS5oU3UxqtyYuXGL2zI9qQM5yMBHH4nRXWALzy7WA==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -8976,7 +8929,6 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.46.0.tgz",
       "integrity": "sha512-VF/MicZ5UOBiXrqBslzwxhN7TVqzu1/LN/QDpkskqM0Zm0aZ4CVRbUygL8d7lrjLn15x5kGIe8VsSphMfPJzlA==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -8994,7 +8946,6 @@
       "version": "0.41.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.41.0.tgz",
       "integrity": "sha512-ivJg4QnnabFxxoI7K8D+in7hfikjte38sYzJB9v1641xJk9Esa7jM3hmbPB7lxwcgWJLVEDvfPwobt1if0tXxA==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -9012,7 +8963,6 @@
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.40.0.tgz",
       "integrity": "sha512-d7ja8yizsOCNMYIJt5PH/fKZXjb/mS48zLROO4BzZTtDfhNCl2UM/9VIomP2qkGIFVouSJrGr/T00EzY7bPtKA==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -9030,7 +8980,6 @@
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.40.0.tgz",
       "integrity": "sha512-0xfS1xcqUmY7WE1uWjlmI67Xg3QsSUlNT+AcXHeA4BDUPwZtWqF4ezIwLgpVZfHOnkAEheqGfNSWd1PIu3Wnfg==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -9048,7 +8997,6 @@
       "version": "0.39.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.39.0.tgz",
       "integrity": "sha512-mewVhEXdikyvIZoMIUry8eb8l3HUjuQjSjVbmLVTt4NQi35tkpnHQrG9bTRBrl3403LoWZ2njMPJyg4l6HfKvA==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -9065,7 +9013,6 @@
       "version": "0.38.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.38.0.tgz",
       "integrity": "sha512-stjow1PijcmUquSmRD/fSihm/H61DbjPlJuJhWUe7P22LFPjFhsrSeiB5vGj3vn+QGceNAs+kioUTzMGPbNxtg==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -9082,7 +9029,6 @@
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.43.0.tgz",
       "integrity": "sha512-og23KLyoxdnAeFs1UWqzSonuCkePUzCX30keSYigIzJe/6WSYA8rnEI5lobcxPEzg+GcU06J7jzokuEHbjVJNw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -9102,7 +9048,6 @@
       "version": "0.41.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.41.0.tgz",
       "integrity": "sha512-Kpv0fJRk/8iMzMk5Ue5BsUJfHkBJ2wQoIi/qduU1a1Wjx9GLj6J2G17PHjPK5mnZjPNzkFOXFADZMfgDioliQw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/api-logs": "^0.52.0",
@@ -9120,7 +9065,6 @@
       "version": "0.41.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.41.0.tgz",
       "integrity": "sha512-RJ1pwI3btykp67ts+5qZbaFSAAzacucwBet5/5EsKYtWBpHbWwV/qbGN/kIBzXg5WEZBhXLrR/RUq0EpEUpL3A==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -9138,7 +9082,6 @@
       "version": "0.41.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.41.1.tgz",
       "integrity": "sha512-UqJAbxraBk7s7pQTlFi5ND4sAUs4r/Ai7gsAVZTQDbHl2kSsOp7gpHcpIuN5dpcI2xnuhM2tkH4SmEhbrv2S6Q==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -9156,7 +9099,6 @@
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.40.0.tgz",
       "integrity": "sha512-sm/rH/GysY/KOEvZqYBZSLYFeXlBkHCgqPDgWc07tz+bHCN6mPs9P3otGOSTe7o3KAIM8Nc6ncCO59vL+jb2cA==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -9174,7 +9116,6 @@
       "version": "0.39.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.39.0.tgz",
       "integrity": "sha512-LaXnVmD69WPC4hNeLzKexCCS19hRLrUw3xicneAMkzJSzNJvPyk7G6I7lz7VjQh1cooObPBt9gNyd3hhTCUrag==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -9191,7 +9132,6 @@
       "version": "0.41.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.41.0.tgz",
       "integrity": "sha512-7fzDe9/FpO6NFizC/wnzXXX7bF9oRchsD//wFqy5g5hVEgXZCQ70IhxjrKdBvgjyIejR9T9zTvfQ6PfVKfkCAw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -9208,7 +9148,6 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.13.0.tgz",
       "integrity": "sha512-Pob0+0R62AqXH50pjazTeGBy/1+SK4CYpFUBV5t7xpbpeuQezkkgVGvLca84QqjBqQizcXedjpUJLgHQDixPQg==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.52.0",
@@ -9226,7 +9165,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.5.0.tgz",
       "integrity": "sha512-aNTeSrFAVcM9qco5DfZ9DNXu6hpMRe8Kt8nCDHfMWDB3pwgGVUE76jTdohc+H/7eLRqh4L7jqs5NSQoHw7S6ww==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -9243,7 +9181,6 @@
       "version": "0.39.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.39.0.tgz",
       "integrity": "sha512-v/1xziLJ9CyB3YDjBSBzbB70Qd0JwWTo36EqWK5m3AR0CzsyMQQmf3ZIZM6sgx7hXMcRQ0pnEYhg6nhrUQPm9A==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/api-logs": "^0.52.0",
@@ -9437,7 +9374,6 @@
       "version": "0.30.16",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.16.tgz",
       "integrity": "sha512-ZVQ3Z/PQ+2GQlrBfbMMMT0U7MzvYZLCPP800+ooyaBqm4hMvuQHfP028gB9/db0mwkmyEAMad9houukUVxhwcw==",
-      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -9450,7 +9386,6 @@
       "version": "1.26.2",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.26.2.tgz",
       "integrity": "sha512-k43wxTjKYvwfce9L4eT8fFYy/ATmCfPHZPZsyT/6ABimf2KE1HafoOsIcxLOtmNSZt6dCvBIYCrXaOWta20xJg==",
-      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -9541,7 +9476,6 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
       "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==",
-      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -9551,7 +9485,6 @@
       "version": "0.29.7",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.29.7.tgz",
       "integrity": "sha512-PExUl/R+reSQI6Y/eNtgAsk6RHk1ElYSzOa8/FHfdc/nLmx9sqMasBEpLMkETkzDP7t27ORuXe4F9vwkV2uwwg==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
@@ -9569,7 +9502,6 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.12.0.tgz",
       "integrity": "sha512-Cvi7ckOqiiuWlHBdA1IjS0ufr3sltex2Uws2RK6loVp4gzIJyOijsddAI6IZ5kiO8h/LgCWe8gxPmwkTKImd+Q==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
@@ -9587,7 +9519,6 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.2.12.tgz",
       "integrity": "sha512-iIarQu6MiCjEEp8dOzmBvCSlRITPFTinFB2oNKAjU6xhx8d7eUcjNOKhBGQTvuCriZrxrEvDaEEY9NfrPQ6uYQ==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.25.1",
@@ -9605,7 +9536,6 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.4.4.tgz",
       "integrity": "sha512-ZEN2mq7lIjQWJ8NTt1umtr6oT/Kb89856BOmESLSvgSHbIwOFYs7cSfSRH5bfiVw6dXTQAVbZA/wLgCHKrebJA==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
@@ -9623,7 +9553,6 @@
       "version": "0.29.13",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.13.tgz",
       "integrity": "sha512-vdotx+l3Q+89PeyXMgKEGnZ/CwzwMtuMi/ddgD9/5tKZ08DfDGB2Npz9m2oXPHRCjc4Ro6ifMqFlRyzIvgOjhg==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
@@ -9987,7 +9916,6 @@
       "version": "0.40.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
       "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@opentelemetry/core": "^1.1.0"
@@ -11660,7 +11588,6 @@
       "version": "8.10.122",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.122.tgz",
       "integrity": "sha512-vBkIh9AY22kVOCEKo5CJlyCgmSWvasC+SWUxL/x/vOwRobMpI/HG1xp/Ae3AqmSiZeLUbOhW0FCD3ZjqqUxmXw==",
-      "license": "MIT",
       "optional": true
     },
     "node_modules/@types/babel__core": {
@@ -11731,7 +11658,6 @@
       "version": "1.8.9",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.9.tgz",
       "integrity": "sha512-ZqS9JGpBxVOvsawzmVt30sP++gSQMTejCkIAQ3VdadOcRE8izTyW66hufvwLeH+YEGP6Js2AW7Gz+RMyvrEbmw==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -11981,7 +11907,6 @@
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.10.tgz",
       "integrity": "sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -12017,7 +11942,6 @@
       "version": "2.15.22",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.22.tgz",
       "integrity": "sha512-wK1pzsJVVAjYCSZWQoWHziQZbNggXFDUEIGf54g4ZM/ERuP86uGdWeKZWMYlqTPMZfHJJvLPyogXGvCOg87yLQ==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -12068,7 +11992,6 @@
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
       "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*",
@@ -12080,7 +12003,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.4.tgz",
       "integrity": "sha512-qZAvkv1K3QbmHHFYSNRYPkRjOWRLBYrL4B9c+wG0GSVGBw0NtJwPcgx/DSddeDJvRGMHCEQ4VMEVfuJ/0gZ3XQ==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/pg": "*"
@@ -12249,7 +12171,6 @@
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
       "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -17207,7 +17128,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/eventid/-/eventid-2.0.1.tgz",
       "integrity": "sha512-sPNTqiMokAvV048P2c9+foqVJzk49o6d4e0D/sq5jog3pw+4kBgyR0gaM1FM7Mx6Kzd9dztesh9oYz1LWWOpzw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "uuid": "^8.0.0"
@@ -17220,7 +17140,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -18487,13 +18406,12 @@
       }
     },
     "node_modules/genkit": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/genkit/-/genkit-1.18.0.tgz",
-      "integrity": "sha512-vu7i25e6f8YV3j4UfxPER2QXWVqY/kpYlw3sexuGOS60a0md/pwlQlIhg++cPAPlvvAb9eQ7ZxlFlUtrHJaiRQ==",
-      "license": "Apache-2.0",
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/genkit/-/genkit-1.19.3.tgz",
+      "integrity": "sha512-v82Nm3Ba5AwsU5qqXjvDY5C7uzCLiRoaeC80q9jl/Y7SFH/fQv6jHkyuoWRVkz3cLtFu7x7oumHH2DVfk7gNLQ==",
       "dependencies": {
-        "@genkit-ai/ai": "1.18.0",
-        "@genkit-ai/core": "1.18.0",
+        "@genkit-ai/ai": "1.19.3",
+        "@genkit-ai/core": "1.19.3",
         "uuid": "^10.0.0"
       }
     },
@@ -18506,12 +18424,11 @@
       "link": true
     },
     "node_modules/genkit/node_modules/@genkit-ai/ai": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/ai/-/ai-1.18.0.tgz",
-      "integrity": "sha512-/rkMAtn3voQ3MhvGult863mrDRf0p86koyYk5Rfh8DSPffy/ir2QVzT1UCmNP/VaXEZig9+vfKh//8COsygUVg==",
-      "license": "Apache-2.0",
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/ai/-/ai-1.19.3.tgz",
+      "integrity": "sha512-a7ggeKV+0CCY/G68Du4Oc36KOnAC3cZ9Eirxc+AGndiRigTOWmQk5UNT/3GItmmaqtTjfPf+YmkuCNWUJ1a1fA==",
       "dependencies": {
-        "@genkit-ai/core": "1.18.0",
+        "@genkit-ai/core": "1.19.3",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.11.19",
         "colorette": "^2.0.20",
@@ -18524,10 +18441,9 @@
       }
     },
     "node_modules/genkit/node_modules/@genkit-ai/core": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/core/-/core-1.18.0.tgz",
-      "integrity": "sha512-meuc5A4cJWI+vMXeaELLRKDx+vytyvVvBSjD6pz6tD66j5H6I25Y9iGmM/UIAHqbrarM5Kl4bKLI8MtD+QSXdA==",
-      "license": "Apache-2.0",
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/core/-/core-1.19.3.tgz",
+      "integrity": "sha512-nnMPMFftaSbFegyEn5RzbTRrJvvHhBO0nNhp3TJQtlmVkCcFMZxSEWOiJ0YsTQLFCaqga7dzjeHhDcA1VTqwJw==",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "~1.25.0",
@@ -18557,7 +18473,6 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
       "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       },
@@ -18569,7 +18484,6 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
       "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.25.1"
       },
@@ -18584,7 +18498,6 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
       "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/semantic-conventions": "1.25.1"
@@ -18600,7 +18513,6 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
       "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/resources": "1.25.1",
@@ -18617,7 +18529,6 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
       "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/resources": "1.25.1",
@@ -18634,7 +18545,6 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
       "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
@@ -18647,7 +18557,6 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -19380,7 +19289,6 @@
       "version": "137.1.0",
       "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-137.1.0.tgz",
       "integrity": "sha512-2L7SzN0FLHyQtFmyIxrcXhgust77067pkkduqkbIpDuj9JzVnByxsRrcRfUMFQam3rQkWW2B0f1i40IwKDWIVQ==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "google-auth-library": "^9.0.0",
@@ -19394,7 +19302,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
       "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "extend": "^3.0.2",
@@ -19416,7 +19323,6 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -21527,7 +21433,6 @@
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/jaeger-client/-/jaeger-client-3.19.0.tgz",
       "integrity": "sha512-M0c7cKHmdyEUtjemnJyx/y9uX16XHocL46yQvyqDlPdvAcwPDbHrIbKjQdBqtiE4apQ/9dmr+ZLJYYPGnurgpw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0",
         "opentracing": "^0.14.4",
@@ -21543,7 +21448,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -23630,7 +23534,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
       "integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
-      "license": "MIT",
       "optional": true
     },
     "node_modules/lodash.memoize": {
@@ -28076,7 +27979,6 @@
       "version": "0.14.7",
       "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
       "integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
       }
@@ -28639,7 +28541,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "license": "ISC",
       "optional": true,
       "engines": {
         "node": ">=4.0.0"
@@ -28649,14 +28550,12 @@
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
       "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
-      "license": "MIT",
       "optional": true
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "pg-int8": "1.0.1",
@@ -29544,7 +29443,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=4"
@@ -29554,7 +29452,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
       "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
-      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -29564,7 +29461,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -29574,7 +29470,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "xtend": "^4.0.0"
@@ -29866,7 +29761,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -29877,7 +29771,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
       "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "duplexify": "^4.1.1",
@@ -33623,7 +33516,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
       "integrity": "sha512-ijUtjmO/n2A5PaosNG9ZGDsQ3vxJg7ZW8vsY8Kp0f2yIZWhSJvjmegV7t+9RPQKxKrvj8yKGehhS+po14hPLGQ==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.6"
       }
@@ -35156,8 +35048,7 @@
     "node_modules/uri-templates": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
-      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
-      "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
+      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg=="
     },
     "node_modules/url-join": {
       "version": "4.0.1",
@@ -35245,7 +35136,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
       "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
-      "license": "BSD",
       "optional": true
     },
     "node_modules/util-deprecate": {
@@ -36417,8 +36307,7 @@
     "node_modules/xorshift": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/xorshift/-/xorshift-1.2.0.tgz",
-      "integrity": "sha512-iYgNnGyeeJ4t6U11NpA/QiKy+PXn5Aa3Azg5qkwIFz1tBLllQrjjsk9yzD7IAK0naNU4JxdeDgqW9ov4u/hc4g==",
-      "license": "MIT"
+      "integrity": "sha512-iYgNnGyeeJ4t6U11NpA/QiKy+PXn5Aa3Azg5qkwIFz1tBLllQrjjsk9yzD7IAK0naNU4JxdeDgqW9ov4u/hc4g=="
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -37124,7 +37013,7 @@
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
-        "genkit": "^0.9.0 || ^1.0.0"
+        "genkit": "^1.19.3"
       }
     },
     "plugins/openai/node_modules/node-fetch": {

--- a/plugins/openai/package.json
+++ b/plugins/openai/package.json
@@ -27,7 +27,7 @@
     "openai": "^4.95.0"
   },
   "peerDependencies": {
-    "genkit": "^0.9.0 || ^1.0.0"
+    "genkit": "^1.19.3"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/plugins/openai/src/dalle.ts
+++ b/plugins/openai/src/dalle.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { GenerateRequest, GenerateResponseData, Genkit } from 'genkit';
+import type { GenerateRequest, GenerateResponseData } from 'genkit';
 import { GenerationCommonConfigSchema, Message, z } from 'genkit';
 import type { ModelAction } from 'genkit/model';
 import { modelRef } from 'genkit/model';
+import { model } from 'genkit/plugin';
 import type OpenAI from 'openai';
 import {
   type ImageGenerateParams,
@@ -90,10 +91,9 @@ function toGenerateResponse(result: ImagesResponse): GenerateResponseData {
 }
 
 export function dallE3Model(
-  ai: Genkit,
   client: OpenAI
 ): ModelAction<typeof DallE3ConfigSchema> {
-  return ai.defineModel<typeof DallE3ConfigSchema>(
+  return model<typeof DallE3ConfigSchema>(
     {
       name: dallE3.name,
       ...dallE3.info,

--- a/plugins/openai/src/dalle.ts
+++ b/plugins/openai/src/dalle.ts
@@ -33,7 +33,7 @@ export const DallE3ConfigSchema = GenerationCommonConfigSchema.extend({
 });
 
 export const dallE3 = modelRef({
-  name: 'openai/dall-e-3',
+  name: 'dall-e-3',
   info: {
     label: 'OpenAI - DALL-E 3',
     supports: {

--- a/plugins/openai/src/embedder.ts
+++ b/plugins/openai/src/embedder.ts
@@ -34,7 +34,7 @@ export type TextEmbeddingGeckoConfig = z.infer<
 export const TextEmbeddingInputSchema = z.string();
 
 export const textEmbedding3Small = createEmbedderRef({
-  name: 'openai/text-embedding-3-small',
+  name: 'text-embedding-3-small',
   configSchema: TextEmbeddingConfigSchema,
   info: {
     dimensions: 1536,
@@ -46,7 +46,7 @@ export const textEmbedding3Small = createEmbedderRef({
 });
 
 export const textEmbedding3Large = createEmbedderRef({
-  name: 'openai/text-embedding-3-large',
+  name: 'text-embedding-3-large',
   configSchema: TextEmbeddingConfigSchema,
   info: {
     dimensions: 3072,
@@ -58,7 +58,7 @@ export const textEmbedding3Large = createEmbedderRef({
 });
 
 export const textEmbeddingAda002 = createEmbedderRef({
-  name: 'openai/text-embedding-ada-002',
+  name: 'text-embedding-ada-002',
   configSchema: TextEmbeddingConfigSchema,
   info: {
     dimensions: 1536,

--- a/plugins/openai/src/embedder.ts
+++ b/plugins/openai/src/embedder.ts
@@ -17,10 +17,10 @@
 // import { defineEmbedder, embedderRef } from '@genkit-ai/ai/embedder';
 
 import OpenAI from 'openai';
-import type { Genkit } from 'genkit';
-import { embedderRef, z } from 'genkit';
+import { embedderRef as createEmbedderRef, z } from 'genkit';
 
 import { type PluginOptions } from './index.js';
+import { embedder } from 'genkit/plugin';
 
 export const TextEmbeddingConfigSchema = z.object({
   dimensions: z.number().optional(),
@@ -33,7 +33,7 @@ export type TextEmbeddingGeckoConfig = z.infer<
 
 export const TextEmbeddingInputSchema = z.string();
 
-export const textEmbedding3Small = embedderRef({
+export const textEmbedding3Small = createEmbedderRef({
   name: 'openai/text-embedding-3-small',
   configSchema: TextEmbeddingConfigSchema,
   info: {
@@ -45,7 +45,7 @@ export const textEmbedding3Small = embedderRef({
   },
 });
 
-export const textEmbedding3Large = embedderRef({
+export const textEmbedding3Large = createEmbedderRef({
   name: 'openai/text-embedding-3-large',
   configSchema: TextEmbeddingConfigSchema,
   info: {
@@ -57,7 +57,7 @@ export const textEmbedding3Large = embedderRef({
   },
 });
 
-export const textEmbeddingAda002 = embedderRef({
+export const textEmbeddingAda002 = createEmbedderRef({
   name: 'openai/text-embedding-ada-002',
   configSchema: TextEmbeddingConfigSchema,
   info: {
@@ -76,7 +76,6 @@ export const SUPPORTED_EMBEDDING_MODELS = {
 };
 
 export function openaiEmbedder(
-  ai: Genkit,
   name: string,
   options?: PluginOptions
 ) {
@@ -85,17 +84,18 @@ export function openaiEmbedder(
     throw new Error(
       'please pass in the API key or set the OPENAI_API_KEY environment variable'
     );
-  const model = SUPPORTED_EMBEDDING_MODELS[name];
-  if (!model) throw new Error(`Unsupported model: ${name}`);
+  const modelRef = SUPPORTED_EMBEDDING_MODELS[name];
+  if (!modelRef) throw new Error(`Unsupported model: ${name}`);
 
   const client = new OpenAI({ apiKey });
-  return ai.defineEmbedder(
+  return embedder(
     {
-      info: model.info!,
+      info: modelRef.info!,
       configSchema: TextEmbeddingConfigSchema,
-      name: model.name,
+      name: modelRef.name,
     },
-    async (input, options) => {
+    async (request, _) => {
+      const { input, options } = request;
       const embeddings = await client.embeddings.create({
         model: name,
         input: input.map((d) => d.text),

--- a/plugins/openai/src/gpt.test.ts
+++ b/plugins/openai/src/gpt.test.ts
@@ -22,8 +22,8 @@ import type {
   ChatCompletionRole,
 } from 'openai/resources/index.mjs';
 import type OpenAI from 'openai';
-import type { GenerateRequest, Genkit, MessageData, Part, Role } from 'genkit';
-import type { CandidateData, ModelAction } from 'genkit/model';
+import type { GenerateRequest, MessageData, Part, Role } from 'genkit';
+import type { CandidateData } from 'genkit/model';
 
 import {
   gpt4o,
@@ -39,9 +39,9 @@ import {
 } from './gpt';
 import type { OpenAiConfigSchema } from './gpt';
 
-jest.mock('@genkit-ai/ai/model', () => ({
-  ...jest.requireActual('@genkit-ai/ai/model'),
-  defineModel: jest.fn(),
+jest.mock('genkit/plugin', () => ({
+  ...jest.requireActual('genkit/plugin'),
+  model: jest.fn(() => ({})),
 }));
 
 describe('toOpenAIRole', () => {
@@ -1358,20 +1358,15 @@ describe('gptRunner', () => {
 });
 
 describe('gptModel', () => {
-  let mockModel: jest.Mock;
-
-  beforeEach(() => {
-    mockModel = jest.fn();
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('should correctly define supported GPT models', () => {
-    jest.spyOn(require('./gpt'), 'model').mockImplementation(mockModel);
+    const { model } = jest.requireMock('genkit/plugin');
+
     gptModel('gpt-4o', {} as OpenAI);
-    expect(mockModel).toHaveBeenCalledWith(
+    expect(model).toHaveBeenCalledWith(
       {
         name: gpt4o.name,
         ...gpt4o.info,
@@ -1382,29 +1377,30 @@ describe('gptModel', () => {
   });
 
   it('should correctly define gpt-4.1, gpt-4.1-mini, and gpt-4.1-nano', () => {
-    jest.spyOn(require('./gpt'), 'model').mockImplementation(mockModel);
+    const { model } = jest.requireMock('genkit/plugin');
+
     gptModel('gpt-4.1', {} as OpenAI);
-    expect(mockModel).toHaveBeenCalledWith(
+    expect(model).toHaveBeenCalledWith(
       {
-        name: 'openai/gpt-4.1',
+        name: 'gpt-4.1',
         ...require('./gpt').gpt41.info,
         configSchema: require('./gpt').gpt41.configSchema,
       },
       expect.any(Function)
     );
     gptModel('gpt-4.1-mini', {} as OpenAI);
-    expect(mockModel).toHaveBeenCalledWith(
+    expect(model).toHaveBeenCalledWith(
       {
-        name: 'openai/gpt-4.1-mini',
+        name: 'gpt-4.1-mini',
         ...require('./gpt').gpt41Mini.info,
         configSchema: require('./gpt').gpt41Mini.configSchema,
       },
       expect.any(Function)
     );
     gptModel('gpt-4.1-nano', {} as OpenAI);
-    expect(mockModel).toHaveBeenCalledWith(
+    expect(model).toHaveBeenCalledWith(
       {
-        name: 'openai/gpt-4.1-nano',
+        name: 'gpt-4.1-nano',
         ...require('./gpt').gpt41Nano.info,
         configSchema: require('./gpt').gpt41Nano.configSchema,
       },

--- a/plugins/openai/src/gpt.test.ts
+++ b/plugins/openai/src/gpt.test.ts
@@ -1358,10 +1358,10 @@ describe('gptRunner', () => {
 });
 
 describe('gptModel', () => {
-  let model: ModelAction;
+  let mockModel: jest.Mock;
 
   beforeEach(() => {
-    model = jest.fn();
+    mockModel = jest.fn();
   });
 
   afterEach(() => {
@@ -1369,9 +1369,9 @@ describe('gptModel', () => {
   });
 
   it('should correctly define supported GPT models', () => {
-    jest.spyOn(model, 'model').mockImplementation((() => ({})) as any);
+    jest.spyOn(require('./gpt'), 'model').mockImplementation(mockModel);
     gptModel('gpt-4o', {} as OpenAI);
-    expect(model).toHaveBeenCalledWith(
+    expect(mockModel).toHaveBeenCalledWith(
       {
         name: gpt4o.name,
         ...gpt4o.info,
@@ -1382,9 +1382,9 @@ describe('gptModel', () => {
   });
 
   it('should correctly define gpt-4.1, gpt-4.1-mini, and gpt-4.1-nano', () => {
-    jest.spyOn(model, 'model').mockImplementation((() => ({})) as any);
+    jest.spyOn(require('./gpt'), 'model').mockImplementation(mockModel);
     gptModel('gpt-4.1', {} as OpenAI);
-    expect(model).toHaveBeenCalledWith(
+    expect(mockModel).toHaveBeenCalledWith(
       {
         name: 'openai/gpt-4.1',
         ...require('./gpt').gpt41.info,
@@ -1393,7 +1393,7 @@ describe('gptModel', () => {
       expect.any(Function)
     );
     gptModel('gpt-4.1-mini', {} as OpenAI);
-    expect(model).toHaveBeenCalledWith(
+    expect(mockModel).toHaveBeenCalledWith(
       {
         name: 'openai/gpt-4.1-mini',
         ...require('./gpt').gpt41Mini.info,
@@ -1402,7 +1402,7 @@ describe('gptModel', () => {
       expect.any(Function)
     );
     gptModel('gpt-4.1-nano', {} as OpenAI);
-    expect(model).toHaveBeenCalledWith(
+    expect(mockModel).toHaveBeenCalledWith(
       {
         name: 'openai/gpt-4.1-nano',
         ...require('./gpt').gpt41Nano.info,

--- a/plugins/openai/src/gpt.test.ts
+++ b/plugins/openai/src/gpt.test.ts
@@ -23,7 +23,7 @@ import type {
 } from 'openai/resources/index.mjs';
 import type OpenAI from 'openai';
 import type { GenerateRequest, Genkit, MessageData, Part, Role } from 'genkit';
-import type { CandidateData } from 'genkit/model';
+import type { CandidateData, ModelAction } from 'genkit/model';
 
 import {
   gpt4o,
@@ -1358,12 +1358,10 @@ describe('gptRunner', () => {
 });
 
 describe('gptModel', () => {
-  let ai: Genkit;
+  let model: ModelAction;
 
   beforeEach(() => {
-    ai = {
-      defineModel: jest.fn(),
-    } as unknown as Genkit;
+    model = jest.fn();
   });
 
   afterEach(() => {
@@ -1371,9 +1369,9 @@ describe('gptModel', () => {
   });
 
   it('should correctly define supported GPT models', () => {
-    jest.spyOn(ai, 'defineModel').mockImplementation((() => ({})) as any);
-    gptModel(ai, 'gpt-4o', {} as OpenAI);
-    expect(ai.defineModel).toHaveBeenCalledWith(
+    jest.spyOn(model, 'model').mockImplementation((() => ({})) as any);
+    gptModel('gpt-4o', {} as OpenAI);
+    expect(model).toHaveBeenCalledWith(
       {
         name: gpt4o.name,
         ...gpt4o.info,
@@ -1384,9 +1382,9 @@ describe('gptModel', () => {
   });
 
   it('should correctly define gpt-4.1, gpt-4.1-mini, and gpt-4.1-nano', () => {
-    jest.spyOn(ai, 'defineModel').mockImplementation((() => ({})) as any);
-    gptModel(ai, 'gpt-4.1', {} as OpenAI);
-    expect(ai.defineModel).toHaveBeenCalledWith(
+    jest.spyOn(model, 'model').mockImplementation((() => ({})) as any);
+    gptModel('gpt-4.1', {} as OpenAI);
+    expect(model).toHaveBeenCalledWith(
       {
         name: 'openai/gpt-4.1',
         ...require('./gpt').gpt41.info,
@@ -1394,8 +1392,8 @@ describe('gptModel', () => {
       },
       expect.any(Function)
     );
-    gptModel(ai, 'gpt-4.1-mini', {} as OpenAI);
-    expect(ai.defineModel).toHaveBeenCalledWith(
+    gptModel('gpt-4.1-mini', {} as OpenAI);
+    expect(model).toHaveBeenCalledWith(
       {
         name: 'openai/gpt-4.1-mini',
         ...require('./gpt').gpt41Mini.info,
@@ -1403,8 +1401,8 @@ describe('gptModel', () => {
       },
       expect.any(Function)
     );
-    gptModel(ai, 'gpt-4.1-nano', {} as OpenAI);
-    expect(ai.defineModel).toHaveBeenCalledWith(
+    gptModel('gpt-4.1-nano', {} as OpenAI);
+    expect(model).toHaveBeenCalledWith(
       {
         name: 'openai/gpt-4.1-nano',
         ...require('./gpt').gpt41Nano.info,

--- a/plugins/openai/src/gpt.ts
+++ b/plugins/openai/src/gpt.ts
@@ -87,7 +87,7 @@ type VisualDetailLevel = z.infer<
 >['visualDetailLevel'];
 
 export const gpt45 = createModelRef({
-  name: 'openai/gpt-4.5',
+  name: 'gpt-4.5',
   info: {
     versions: ['gpt-4.5-preview'],
     label: 'OpenAI - GPT-4.5',
@@ -103,7 +103,7 @@ export const gpt45 = createModelRef({
 });
 
 export const gpt4o = createModelRef({
-  name: 'openai/gpt-4o',
+  name: 'gpt-4o',
   info: {
     versions: ['gpt-4o', 'gpt-4o-2024-05-13'],
     label: 'OpenAI - GPT-4o',
@@ -119,7 +119,7 @@ export const gpt4o = createModelRef({
 });
 
 export const o1Preview = createModelRef({
-  name: 'openai/o1-preview',
+  name: 'o1-preview',
   info: {
     versions: ['o1-preview'],
     label: 'OpenAI - o1 Preview',
@@ -135,7 +135,7 @@ export const o1Preview = createModelRef({
 });
 
 export const o1Mini = createModelRef({
-  name: 'openai/o1',
+  name: 'o1',
   info: {
     versions: ['o1-mini'],
     label: 'OpenAI - o1 Mini',
@@ -151,7 +151,7 @@ export const o1Mini = createModelRef({
 });
 
 export const o1 = createModelRef({
-  name: 'openai/o1',
+  name: 'o1',
   info: {
     versions: ['o1'],
     label: 'OpenAI - o1',
@@ -167,7 +167,7 @@ export const o1 = createModelRef({
 });
 
 export const o3 = createModelRef({
-  name: 'openai/o3',
+  name: 'o3',
   info: {
     versions: ['o3'],
     label: 'OpenAI - o3',
@@ -183,7 +183,7 @@ export const o3 = createModelRef({
 });
 
 export const o3Mini = createModelRef({
-  name: 'openai/o3-mini',
+  name: 'o3-mini',
   info: {
     versions: ['o3-mini'],
     label: 'OpenAI - o3 Mini',
@@ -199,7 +199,7 @@ export const o3Mini = createModelRef({
 });
 
 export const o4Mini = createModelRef({
-  name: 'openai/o4-mini',
+  name: 'o4-mini',
   info: {
     versions: ['o4-mini'],
     label: 'OpenAI - o4 Mini',
@@ -215,7 +215,7 @@ export const o4Mini = createModelRef({
 });
 
 export const gpt4oMini = createModelRef({
-  name: 'openai/gpt-4o-mini',
+  name: 'gpt-4o-mini',
   info: {
     versions: ['gpt-4o-mini', 'gpt-4o-mini-2024-07-18'],
     label: 'OpenAI - GPT-4o mini',
@@ -231,7 +231,7 @@ export const gpt4oMini = createModelRef({
 });
 
 export const gpt4Turbo = createModelRef({
-  name: 'openai/gpt-4-turbo',
+  name: 'gpt-4-turbo',
   info: {
     versions: [
       'gpt-4-turbo',
@@ -253,7 +253,7 @@ export const gpt4Turbo = createModelRef({
 });
 
 export const gpt4Vision = createModelRef({
-  name: 'openai/gpt-4-vision',
+  name: 'gpt-4-vision',
   info: {
     versions: ['gpt-4-vision-preview', 'gpt-4-1106-vision-preview'],
     label: 'OpenAI - GPT-4 Vision',
@@ -269,7 +269,7 @@ export const gpt4Vision = createModelRef({
 });
 
 export const gpt4 = createModelRef({
-  name: 'openai/gpt-4',
+  name: 'gpt-4',
   info: {
     versions: ['gpt-4', 'gpt-4-0613', 'gpt-4-32k', 'gpt-4-32k-0613'],
     label: 'OpenAI - GPT-4',
@@ -285,7 +285,7 @@ export const gpt4 = createModelRef({
 });
 
 export const gpt41 = createModelRef({
-  name: 'openai/gpt-4.1',
+  name: 'gpt-4.1',
   info: {
     versions: ['gpt-4.1'],
     label: 'OpenAI - GPT-4.1',
@@ -301,7 +301,7 @@ export const gpt41 = createModelRef({
 });
 
 export const gpt41Mini = createModelRef({
-  name: 'openai/gpt-4.1-mini',
+  name: 'gpt-4.1-mini',
   info: {
     versions: ['gpt-4.1-mini'],
     label: 'OpenAI - GPT-4.1 Mini',
@@ -317,7 +317,7 @@ export const gpt41Mini = createModelRef({
 });
 
 export const gpt41Nano = createModelRef({
-  name: 'openai/gpt-4.1-nano',
+  name: 'gpt-4.1-nano',
   info: {
     versions: ['gpt-4.1-nano'],
     label: 'OpenAI - GPT-4.1 Nano',
@@ -333,7 +333,7 @@ export const gpt41Nano = createModelRef({
 });
 
 export const gpt35Turbo = createModelRef({
-  name: 'openai/gpt-3.5-turbo',
+  name: 'gpt-3.5-turbo',
   info: {
     versions: ['gpt-3.5-turbo-0125', 'gpt-3.5-turbo', 'gpt-3.5-turbo-1106'],
     label: 'OpenAI - GPT-3.5 Turbo',
@@ -768,7 +768,7 @@ export function gptModel(
   modelInfo?: ModelInfo,
   modelConfig?: any
 ): ModelAction<typeof OpenAiConfigSchema> {
-  const modelId = `openai/${name}`;
+  const modelId = `${name}`;
   const modelRef = SUPPORTED_GPT_MODELS[name];
   if (!modelRef) {
     SUPPORTED_GPT_MODELS[name] = createModelRef({

--- a/plugins/openai/src/gpt.ts
+++ b/plugins/openai/src/gpt.ts
@@ -19,7 +19,6 @@ import type {
   StreamingCallback,
   GenerateRequest,
   GenerateResponseData,
-  Genkit,
   MessageData,
   ModelReference,
   Part,
@@ -32,7 +31,7 @@ import type {
   ModelAction,
   ToolDefinition,
 } from 'genkit/model';
-import { modelRef } from 'genkit/model';
+import { modelRef as createModelRef } from 'genkit/model';
 import type OpenAI from 'openai';
 import {
   type ChatCompletion,
@@ -45,6 +44,7 @@ import {
   type ChatCompletionTool,
   type CompletionChoice,
 } from 'openai/resources/index.mjs';
+import { model } from 'genkit/plugin';
 
 const MODELS_SUPPORTING_OPENAI_RESPONSE_FORMAT = [
   'gpt-4.5-preview',
@@ -86,7 +86,7 @@ type VisualDetailLevel = z.infer<
   typeof OpenAiConfigSchema
 >['visualDetailLevel'];
 
-export const gpt45 = modelRef({
+export const gpt45 = createModelRef({
   name: 'openai/gpt-4.5',
   info: {
     versions: ['gpt-4.5-preview'],
@@ -102,7 +102,7 @@ export const gpt45 = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const gpt4o = modelRef({
+export const gpt4o = createModelRef({
   name: 'openai/gpt-4o',
   info: {
     versions: ['gpt-4o', 'gpt-4o-2024-05-13'],
@@ -118,7 +118,7 @@ export const gpt4o = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const o1Preview = modelRef({
+export const o1Preview = createModelRef({
   name: 'openai/o1-preview',
   info: {
     versions: ['o1-preview'],
@@ -134,7 +134,7 @@ export const o1Preview = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const o1Mini = modelRef({
+export const o1Mini = createModelRef({
   name: 'openai/o1',
   info: {
     versions: ['o1-mini'],
@@ -150,7 +150,7 @@ export const o1Mini = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const o1 = modelRef({
+export const o1 = createModelRef({
   name: 'openai/o1',
   info: {
     versions: ['o1'],
@@ -166,7 +166,7 @@ export const o1 = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const o3 = modelRef({
+export const o3 = createModelRef({
   name: 'openai/o3',
   info: {
     versions: ['o3'],
@@ -182,7 +182,7 @@ export const o3 = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const o3Mini = modelRef({
+export const o3Mini = createModelRef({
   name: 'openai/o3-mini',
   info: {
     versions: ['o3-mini'],
@@ -198,7 +198,7 @@ export const o3Mini = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const o4Mini = modelRef({
+export const o4Mini = createModelRef({
   name: 'openai/o4-mini',
   info: {
     versions: ['o4-mini'],
@@ -214,7 +214,7 @@ export const o4Mini = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const gpt4oMini = modelRef({
+export const gpt4oMini = createModelRef({
   name: 'openai/gpt-4o-mini',
   info: {
     versions: ['gpt-4o-mini', 'gpt-4o-mini-2024-07-18'],
@@ -230,7 +230,7 @@ export const gpt4oMini = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const gpt4Turbo = modelRef({
+export const gpt4Turbo = createModelRef({
   name: 'openai/gpt-4-turbo',
   info: {
     versions: [
@@ -252,7 +252,7 @@ export const gpt4Turbo = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const gpt4Vision = modelRef({
+export const gpt4Vision = createModelRef({
   name: 'openai/gpt-4-vision',
   info: {
     versions: ['gpt-4-vision-preview', 'gpt-4-1106-vision-preview'],
@@ -268,7 +268,7 @@ export const gpt4Vision = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const gpt4 = modelRef({
+export const gpt4 = createModelRef({
   name: 'openai/gpt-4',
   info: {
     versions: ['gpt-4', 'gpt-4-0613', 'gpt-4-32k', 'gpt-4-32k-0613'],
@@ -284,7 +284,7 @@ export const gpt4 = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const gpt41 = modelRef({
+export const gpt41 = createModelRef({
   name: 'openai/gpt-4.1',
   info: {
     versions: ['gpt-4.1'],
@@ -300,7 +300,7 @@ export const gpt41 = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const gpt41Mini = modelRef({
+export const gpt41Mini = createModelRef({
   name: 'openai/gpt-4.1-mini',
   info: {
     versions: ['gpt-4.1-mini'],
@@ -316,7 +316,7 @@ export const gpt41Mini = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const gpt41Nano = modelRef({
+export const gpt41Nano = createModelRef({
   name: 'openai/gpt-4.1-nano',
   info: {
     versions: ['gpt-4.1-nano'],
@@ -332,7 +332,7 @@ export const gpt41Nano = modelRef({
   configSchema: OpenAiConfigSchema,
 });
 
-export const gpt35Turbo = modelRef({
+export const gpt35Turbo = createModelRef({
   name: 'openai/gpt-3.5-turbo',
   info: {
     versions: ['gpt-3.5-turbo-0125', 'gpt-3.5-turbo', 'gpt-3.5-turbo-1106'],
@@ -763,16 +763,15 @@ export function gptRunner(name: string, client: OpenAI) {
  * @throws An error if the specified model is not supported.
  */
 export function gptModel(
-  ai: Genkit,
   name: string,
   client: OpenAI,
   modelInfo?: ModelInfo,
   modelConfig?: any
 ): ModelAction<typeof OpenAiConfigSchema> {
   const modelId = `openai/${name}`;
-  const model = SUPPORTED_GPT_MODELS[name];
-  if (!model) {
-    SUPPORTED_GPT_MODELS[name] = modelRef({
+  const modelRef = SUPPORTED_GPT_MODELS[name];
+  if (!modelRef) {
+    SUPPORTED_GPT_MODELS[name] = createModelRef({
       name: modelId,
       info: modelInfo,
       configSchema: modelConfig?.configSchema,
@@ -780,17 +779,26 @@ export function gptModel(
   }
 
   // Use the built-in model info and config schema or override if provided
-  const modelInformation = modelInfo ? modelInfo : model.info;
+  const modelInformation = modelInfo ? modelInfo : modelRef.info;
   const configSchema = modelConfig
     ? modelConfig.configSchema
-    : model.configSchema;
+    : modelRef.configSchema;
 
-  return ai.defineModel(
+  return model(
     {
       name: modelId,
       ...modelInformation,
       configSchema,
     },
-    gptRunner(name, client)
+    // The gptRunner signature expects (request, streamingCallback?), but model expects (request, options?)
+    // So we wrap gptRunner to adapt the signature.
+    (request, options) => {
+      // If options is a function, treat as streamingCallback, else ignore.
+      // This ensures compatibility with the expected StreamingCallback signature.
+      if (typeof options === 'function') {
+        return gptRunner(name, client)(request, options);
+      }
+      return gptRunner(name, client)(request);
+    }
   );
 }

--- a/plugins/openai/src/index.ts
+++ b/plugins/openai/src/index.ts
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { Genkit } from 'genkit';
-import { genkitPlugin } from 'genkit/plugin';
+import { genkitPluginV2, ResolvableAction } from 'genkit/plugin';
 import { ClientOptions, OpenAI } from 'openai';
 
 import { ModelInfo } from 'genkit/model';
@@ -141,28 +140,35 @@ export interface ModelDefinition {
  * ```
  */
 export const openAI = (options?: PluginOptions) =>
-  genkitPlugin('openai', async (ai: Genkit) => {
-    const client = new OpenAI(options);
-    for (const name of Object.keys(SUPPORTED_GPT_MODELS)) {
-      gptModel(ai, name, client);
-    }
-    // Initialize the models if provided in the options
-    options?.models?.map((model) => {
-      if (!model.name || !model.info || !model.configSchema) {
-        throw new Error(`Model ${model.name} is missing required fields`);
-      }
-      gptModel(ai, model.name, client, model.info, model.configSchema);
-    });
+  genkitPluginV2({
+    name: 'openai',
+    init: () => {
+      const client = new OpenAI(options);
+      const actions: ResolvableAction[] = [];
 
-    dallE3Model(ai, client);
-    for (const name of Object.keys(SUPPORTED_STT_MODELS)) {
-      sttModel(ai, name, client);
-    }
-    for (const name of Object.keys(SUPPORTED_TTS_MODELS)) {
-      ttsModel(ai, name, client);
-    }
-    for (const name of Object.keys(SUPPORTED_EMBEDDING_MODELS)) {
-      openaiEmbedder(ai, name, options);
+      for (const name of Object.keys(SUPPORTED_GPT_MODELS)) {
+        actions.push(gptModel(name, client));
+      }
+      // Initialize the models if provided in the options
+      options?.models?.map((model) => {
+        if (!model.name || !model.info || !model.configSchema) {
+          throw new Error(`Model ${model.name} is missing required fields`);
+        }
+        actions.push(gptModel(model.name, client, model.info, model.configSchema));
+      });
+
+      actions.push(dallE3Model(client));
+      for (const name of Object.keys(SUPPORTED_STT_MODELS)) {
+        actions.push(sttModel(name, client));
+      }
+      for (const name of Object.keys(SUPPORTED_TTS_MODELS)) {
+        actions.push(ttsModel(name, client));
+      }
+      for (const name of Object.keys(SUPPORTED_EMBEDDING_MODELS)) {
+        actions.push(openaiEmbedder(name, options));
+      }
+
+      return actions;
     }
   });
 

--- a/plugins/openai/src/tts.ts
+++ b/plugins/openai/src/tts.ts
@@ -33,7 +33,7 @@ export const TTSConfigSchema = GenerationCommonConfigSchema.extend({
 });
 
 export const tts1 = createModelRef({
-  name: 'openai/tts-1',
+  name: 'tts-1',
   info: {
     label: 'OpenAI - Text-to-speech 1',
     supports: {
@@ -48,7 +48,7 @@ export const tts1 = createModelRef({
 });
 
 export const tts1Hd = createModelRef({
-  name: 'openai/tts-1-hd',
+  name: 'tts-1-hd',
   info: {
     label: 'OpenAI - Text-to-speech 1 HD',
     supports: {
@@ -63,7 +63,7 @@ export const tts1Hd = createModelRef({
 });
 
 export const gpt4oMiniTts = createModelRef({
-  name: 'openai/gpt-4o-mini-tts',
+  name: 'gpt-4o-mini-tts',
   info: {
     label: 'OpenAI - GPT-4o Mini Text-to-speech',
     supports: {
@@ -142,7 +142,7 @@ export function ttsModel(
   name: string,
   client: OpenAI
 ): ModelAction<typeof TTSConfigSchema> {
-  const modelId = `openai/${name}`;
+  const modelId = `${name}`;
   const modelRef = SUPPORTED_TTS_MODELS[name];
   if (!modelRef) throw new Error(`Unsupported model: ${name}`);
 

--- a/plugins/openai/src/tts.ts
+++ b/plugins/openai/src/tts.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { GenerateRequest, GenerateResponseData, Genkit } from 'genkit';
+import type { GenerateRequest, GenerateResponseData } from 'genkit';
 import { GenerationCommonConfigSchema, Message, z } from 'genkit';
 import type { ModelAction } from 'genkit/model';
-import { modelRef } from 'genkit/model';
+import { modelRef as createModelRef } from 'genkit/model';
+import { model } from 'genkit/plugin';
 import type OpenAI from 'openai';
 import { type SpeechCreateParams } from 'openai/resources/audio/index.mjs';
 
@@ -31,7 +32,7 @@ export const TTSConfigSchema = GenerationCommonConfigSchema.extend({
     .optional(),
 });
 
-export const tts1 = modelRef({
+export const tts1 = createModelRef({
   name: 'openai/tts-1',
   info: {
     label: 'OpenAI - Text-to-speech 1',
@@ -46,7 +47,7 @@ export const tts1 = modelRef({
   configSchema: TTSConfigSchema,
 });
 
-export const tts1Hd = modelRef({
+export const tts1Hd = createModelRef({
   name: 'openai/tts-1-hd',
   info: {
     label: 'OpenAI - Text-to-speech 1 HD',
@@ -61,7 +62,7 @@ export const tts1Hd = modelRef({
   configSchema: TTSConfigSchema,
 });
 
-export const gpt4oMiniTts = modelRef({
+export const gpt4oMiniTts = createModelRef({
   name: 'openai/gpt-4o-mini-tts',
   info: {
     label: 'OpenAI - GPT-4o Mini Text-to-speech',
@@ -138,19 +139,18 @@ function toGenerateResponse(
 }
 
 export function ttsModel(
-  ai: Genkit,
   name: string,
   client: OpenAI
 ): ModelAction<typeof TTSConfigSchema> {
   const modelId = `openai/${name}`;
-  const model = SUPPORTED_TTS_MODELS[name];
-  if (!model) throw new Error(`Unsupported model: ${name}`);
+  const modelRef = SUPPORTED_TTS_MODELS[name];
+  if (!modelRef) throw new Error(`Unsupported model: ${name}`);
 
-  return ai.defineModel<typeof TTSConfigSchema>(
+  return model<typeof TTSConfigSchema>(
     {
       name: modelId,
-      ...model.info,
-      configSchema: model.configSchema,
+      ...modelRef.info,
+      configSchema: modelRef.configSchema,
     },
     async (request) => {
       const ttsRequest = toTTSRequest(name, request);

--- a/plugins/openai/src/whisper.ts
+++ b/plugins/openai/src/whisper.ts
@@ -33,7 +33,7 @@ export const Whisper1ConfigSchema = GenerationCommonConfigSchema.extend({
 });
 
 export const whisper1 = createModelRef({
-  name: 'openai/whisper-1',
+  name: 'whisper-1',
   info: {
     label: 'OpenAI - Whisper',
     supports: {
@@ -48,7 +48,7 @@ export const whisper1 = createModelRef({
 });
 
 export const gpt4oTranscribe = createModelRef({
-  name: 'openai/gpt-4o-transcribe',
+  name: 'gpt-4o-transcribe',
   info: {
     label: 'OpenAI - GPT-4o Transcribe',
     supports: {
@@ -142,7 +142,7 @@ export function sttModel(
   name: string,
   client: OpenAI
 ): ModelAction<typeof Whisper1ConfigSchema> {
-  const modelId = `openai/${name}`;
+  const modelId = `${name}`;
   const modelRef = SUPPORTED_STT_MODELS[name];
   if (!modelRef) throw new Error(`Unsupported model: ${name}`);
 

--- a/plugins/openai/src/whisper.ts
+++ b/plugins/openai/src/whisper.ts
@@ -13,10 +13,11 @@
  * limitations under the License.
  */
 
-import type { GenerateRequest, GenerateResponseData, Genkit } from 'genkit';
+import type { GenerateRequest, GenerateResponseData } from 'genkit';
 import { GenerationCommonConfigSchema, Message, z } from 'genkit';
 import type { ModelAction } from 'genkit/model';
-import { modelRef } from 'genkit/model';
+import { modelRef as createModelRef } from 'genkit/model';
+import { model } from 'genkit/plugin';
 import type OpenAI from 'openai';
 import {
   type TranscriptionCreateParams,
@@ -31,7 +32,7 @@ export const Whisper1ConfigSchema = GenerationCommonConfigSchema.extend({
     .optional(),
 });
 
-export const whisper1 = modelRef({
+export const whisper1 = createModelRef({
   name: 'openai/whisper-1',
   info: {
     label: 'OpenAI - Whisper',
@@ -46,7 +47,7 @@ export const whisper1 = modelRef({
   configSchema: Whisper1ConfigSchema,
 });
 
-export const gpt4oTranscribe = modelRef({
+export const gpt4oTranscribe = createModelRef({
   name: 'openai/gpt-4o-transcribe',
   info: {
     label: 'OpenAI - GPT-4o Transcribe',
@@ -138,19 +139,18 @@ export const SUPPORTED_STT_MODELS = {
 };
 
 export function sttModel(
-  ai: Genkit,
   name: string,
   client: OpenAI
 ): ModelAction<typeof Whisper1ConfigSchema> {
   const modelId = `openai/${name}`;
-  const model = SUPPORTED_STT_MODELS[name];
-  if (!model) throw new Error(`Unsupported model: ${name}`);
+  const modelRef = SUPPORTED_STT_MODELS[name];
+  if (!modelRef) throw new Error(`Unsupported model: ${name}`);
 
-  return ai.defineModel<typeof Whisper1ConfigSchema>(
+  return model<typeof Whisper1ConfigSchema>(
     {
       name: modelId,
-      ...model.info,
-      configSchema: model.configSchema,
+      ...modelRef.info,
+      configSchema: modelRef.configSchema,
     },
     async (request) => {
       const params = toWhisper1Request(request);


### PR DESCRIPTION
Resolves https://github.com/BloomLabsInc/genkit-plugins/issues/357

**What this does**
- Upgrades Genkit to the latest version
- Migrates the plugin API to v2 ([doc](https://docs.google.com/document/d/1s1YKwhqdrGN44IG7lSAwltxM3Bqh9p6jTcri8SNaBWk/edit?tab=t.0#heading=h.5nmgndd9f76y))

**Testing**
  - [ ] Checked that the models and embedders load with the same names/prefixes on the UI.
  - [ ] Checked that at least one model works consistent with pre-migration on the UI.
  - [ ] Checked that at least one embedder works consistent with pre-migration on the UI.
  - [ ] Using a model object, checked using a flow works consistent with pre-migration.
  - [ ] Using an embedder object, checked using a flow works consistent with pre-migration.
  - [ ] Using a model string (`'pluginName/modelName'`), checked using a flow works consistent with pre-migration.
  - [ ] Using an embedder string, checked using a flow works consistent with pre-migration.
  - [ ] Tested error response from embedder.
  - [ ] Tested error response from model.
  - [ ] Tested resolve