### PR TITLE
feat: Add Valkey plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This repository contains community plugins for
 - [`genkitx-convex`](plugins/convex/README.md) - Plugin for Convex Vector Stores
 - [`genkitx-hnsw`](plugins/hnsw/README.md) - Plugin for HNSW Vector Stores
 - [`genkitx-milvus`](plugins/milvus/README.md) - Plugin for Milvus Vector Database
+- [`genkitx-valkey`](plugins/valkey/README.md) - Plugin for Valkey Vector Database
 
 ### Other Plugins
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12231,6 +12231,105 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "license": "ISC"
     },
+    "node_modules/@valkey/valkey-glide": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide/-/valkey-glide-2.4.0.tgz",
+      "integrity": "sha512-kSD0X/TCIBoUdSrXI9HbO6ZEtAdbC5FNWNPRcJQSbIfhKpqUQkdoF+7VHhJM4u9c3OhOgrDry436KE/VAnwP2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "long": "5",
+        "protobufjs": "7"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@valkey/valkey-glide-darwin-arm64": "2.4.0",
+        "@valkey/valkey-glide-darwin-x64": "2.4.0",
+        "@valkey/valkey-glide-linux-arm64-gnu": "2.4.0",
+        "@valkey/valkey-glide-linux-arm64-musl": "2.4.0",
+        "@valkey/valkey-glide-linux-x64-gnu": "2.4.0",
+        "@valkey/valkey-glide-linux-x64-musl": "2.4.0"
+      }
+    },
+    "node_modules/@valkey/valkey-glide-darwin-arm64": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-darwin-arm64/-/valkey-glide-darwin-arm64-2.4.0.tgz",
+      "integrity": "sha512-ET1diKJc84APH5P4kisiVr8Ys2lmNV3rezMa2fLwZ1vP6pdB9KQZxbdnib3cdrqXsG2q0QAFnF39l+k56QSgeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@valkey/valkey-glide-darwin-x64": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-darwin-x64/-/valkey-glide-darwin-x64-2.4.0.tgz",
+      "integrity": "sha512-hMnQTYqOugiSUH26KwVII20Pj8vacSyKqt52XIFn5y0XPwEHuHCeTdorch4dLeLT+/2h0hS0wrJBuOYGmdxRuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@valkey/valkey-glide-linux-arm64-gnu": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-arm64-gnu/-/valkey-glide-linux-arm64-gnu-2.4.0.tgz",
+      "integrity": "sha512-8yXVEYRh1pbpWaoVWh096JrvtSjdPNVexjpAdmbyMzOuGMGnNVyjrnH8+l1iA2qBqglj+4KQPD3FMpxAGDZXXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@valkey/valkey-glide-linux-arm64-musl": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-arm64-musl/-/valkey-glide-linux-arm64-musl-2.4.0.tgz",
+      "integrity": "sha512-is8IvM2AZ2bhDXHMktOez/6owGWsdM8BsHrUT46unqCXwRWSOMUhdNG8lNxmcajhgHkM8EYCUqwQCKvhzvLW/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@valkey/valkey-glide-linux-x64-gnu": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-x64-gnu/-/valkey-glide-linux-x64-gnu-2.4.0.tgz",
+      "integrity": "sha512-2CtNW0qkYLkbMULrPBCj2xb0AzBANZ0INTkXhO5HG0RhOCtXepwJQfs+PZsxJUDgODjWt6TYfsQsrkWKN9vQ2g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@valkey/valkey-glide-linux-x64-musl": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-x64-musl/-/valkey-glide-linux-x64-musl-2.4.0.tgz",
+      "integrity": "sha512-Or4z46RwjkjIwEoZGL84dvErKfbNFFT+GDsIhQ3E3pAtMLVM8s6y/eP168y13v8Z4lXNkMddFL0z3xYJDGofSg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -14426,132 +14525,6 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/cohere-ai": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/cohere-ai/-/cohere-ai-7.14.0.tgz",
-      "integrity": "sha512-hSo2/tFV29whjFFtVtdS7kHmtUsjfMO1sgwE/d5bhOE4O7Vkj5G1R9lLIqkIprp/+rrvCq3HGvEaOgry7xRcDA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/client-sagemaker": "^3.583.0",
-        "@aws-sdk/credential-providers": "^3.583.0",
-        "@aws-sdk/protocol-http": "^3.374.0",
-        "@aws-sdk/signature-v4": "^3.374.0",
-        "form-data": "^4.0.0",
-        "form-data-encoder": "^4.0.2",
-        "formdata-node": "^6.0.3",
-        "js-base64": "3.7.2",
-        "node-fetch": "2.7.0",
-        "qs": "6.11.2",
-        "readable-stream": "^4.5.2",
-        "url-join": "4.0.1"
-      }
-    },
-    "node_modules/cohere-ai/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/cohere-ai/node_modules/form-data-encoder": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.0.2.tgz",
-      "integrity": "sha512-KQVhvhK8ZkWzxKxOr56CPulAhH3dobtuQ4+hNQ+HekH/Wp5gSOafqRAeTphQUJAIk0GBvHZgJ2ZGRWd5kphMuw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/cohere-ai/node_modules/formdata-node": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-6.0.3.tgz",
-      "integrity": "sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/cohere-ai/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/cohere-ai/node_modules/qs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/cohere-ai/node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/collapse-white-space": {
@@ -18624,6 +18597,10 @@
     },
     "node_modules/genkitx-openai-example": {
       "resolved": "examples/openai",
+      "link": true
+    },
+    "node_modules/genkitx-valkey": {
+      "resolved": "plugins/valkey",
       "link": true
     },
     "node_modules/gensync": {
@@ -27898,75 +27875,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/openai": {
-      "version": "4.72.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.72.0.tgz",
-      "integrity": "sha512-hFqG9BWCs7L7ifrhJXw7mJXmUBr7d9N6If3J9563o0jfwVA4wFANFDDaOIWFdgDdwgCXg5emf0Q+LoLCGszQYA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.64",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.64.tgz",
-      "integrity": "sha512-955mDqvO2vFf/oL7V3WiUtiz+BugyX8uVbaT2H8oj3+8dRyH2FLiNdowe7eNqRM7IOIZvzDH76EoAT+gwm6aIQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -36591,29 +36499,6 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
-    "plugins/azure-openai/node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "plugins/cohere": {
       "name": "genkitx-cohere",
       "version": "0.30.0",
@@ -37091,27 +36976,26 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
-    "plugins/openai/node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
+    "plugins/valkey": {
+      "name": "genkitx-valkey",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@valkey/valkey-glide": "2.4.0"
+      },
+      "devDependencies": {
+        "@jest/globals": "^29.7.0",
+        "@types/jest": "^29.5.12",
+        "@types/node": "^20.11.16",
+        "jest": "^29.7.0",
+        "npm-run-all": "^4.1.5",
+        "rimraf": "^6.0.1",
+        "ts-jest": "^29.1.2",
+        "tsup": "^8.0.2",
+        "typescript": "^5.6.3"
       },
       "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "genkit": "^0.9.0 || ^1.0.0"
       }
     }
   }

--- a/plugins/valkey/.gitignore
+++ b/plugins/valkey/.gitignore
@@ -1,0 +1,3 @@
+lib/
+node_modules/
+coverage/

--- a/plugins/valkey/.npmignore
+++ b/plugins/valkey/.npmignore
@@ -1,0 +1,6 @@
+src
+test
+tsconfig.json
+tsup.config.ts
+jest.config.js
+.gitignore

--- a/plugins/valkey/LICENSE
+++ b/plugins/valkey/LICENSE
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+  Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   

--- a/plugins/valkey/README.md
+++ b/plugins/valkey/README.md
@@ -1,0 +1,86 @@
+# genkitx-valkey
+
+Genkit AI framework plugin for Valkey vector database.
+
+This plugin provides `Indexer` and `Retriever` implementations backed by
+[Valkey](https://valkey.io/) with the
+[valkey-search](https://github.com/valkey-io/valkey-search) module loaded.
+
+## Prerequisites
+
+Your Valkey instance must have the `valkey-search` module loaded. This enables
+the `FT.CREATE` and `FT.SEARCH` commands used for vector indexing and KNN
+retrieval.
+
+- **Docker**: use `valkey/valkey-bundle` which bundles the module.
+- **ElastiCache**: engine versions that include `valkey-search` work
+  out-of-the-box.
+- **Manual**: pass `--loadmodule /path/to/libsearch.so` at startup.
+
+## Installation
+
+```bash
+npm install genkitx-valkey
+```
+
+## Usage
+
+```typescript
+import { genkit } from 'genkit';
+import { valkeyPlugin, valkeyIndexer, valkeyRetriever } from 'genkitx-valkey';
+
+const { plugin, close } = valkeyPlugin([
+  {
+    indexName: 'docs',
+    embedder: 'googleai/gemini-embedding-001',
+    dimension: 768,
+    clientConfig: {
+      addresses: [{ host: 'localhost', port: 6379 }],
+    },
+  },
+]);
+
+const ai = genkit({ plugins: [plugin] });
+
+// Index documents
+await ai.index({
+  indexer: valkeyIndexer({ indexName: 'docs' }),
+  documents: [
+    { content: [{ text: 'Valkey is an open-source key-value store.' }] },
+  ],
+});
+
+// Retrieve documents
+const docs = await ai.retrieve({
+  retriever: valkeyRetriever({ indexName: 'docs' }),
+  query: 'What is Valkey?',
+  options: { k: 3 },
+});
+
+// Cleanup on shutdown
+await close();
+```
+
+## Configuration
+
+Each entry in the plugin params array accepts:
+
+| Option            | Type                       | Required | Description                                       |
+| ----------------- | -------------------------- | -------- | ------------------------------------------------- |
+| `indexName`       | `string`                   | Yes      | Name of the FT index in Valkey                    |
+| `embedder`        | `EmbedderArgument`         | Yes      | Genkit embedder reference                         |
+| `dimension`       | `number`                   | Yes      | Embedding vector dimension                        |
+| `clientConfig`    | `GlideClientConfiguration` | Yes      | Connection config for `@valkey/valkey-glide`      |
+| `embedderOptions` | `object`                   | No       | Options passed to the embedder                    |
+| `prefix`          | `string`                   | No       | Hash key prefix (defaults to `indexName`)         |
+| `distanceMetric`  | `'COSINE' \| 'L2' \| 'IP'` | No       | HNSW distance metric (defaults to `COSINE`)       |
+| `metadataFields`  | `ValkeyMetadataField[]`    | No       | Metadata fields to index for query-time filtering |
+
+## Limitations
+
+- **Standalone mode only**: This plugin uses `GlideClient` (standalone). Cluster
+  deployments (`GlideClusterClient`) are not yet supported.
+
+## License
+
+Apache-2.0

--- a/plugins/valkey/jest.config.js
+++ b/plugins/valkey/jest.config.js
@@ -1,0 +1,14 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  clearMocks: true,
+  preset: 'ts-jest',
+  testMatch: ['**/test/**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  transformIgnorePatterns: ['/node_modules/'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/plugins/valkey/package.json
+++ b/plugins/valkey/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "genkitx-valkey",
+  "description": "Genkit AI framework plugin for Valkey vector database.",
+  "keywords": [
+    "genkit",
+    "genkit-retriever",
+    "genkit-plugin",
+    "genkit-indexer",
+    "valkey",
+    "vector",
+    "embedding",
+    "ai",
+    "genai",
+    "generative-ai"
+  ],
+  "version": "0.1.0",
+  "type": "commonjs",
+  "scripts": {
+    "check": "tsc",
+    "compile": "tsup-node",
+    "build:clean": "rimraf ./lib",
+    "build": "npm-run-all build:clean check compile",
+    "build:watch": "tsup-node --watch",
+    "test": "jest --coverage"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BloomLabsInc/genkit-plugins.git",
+    "directory": "plugins/valkey"
+  },
+  "author": "genkit",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@valkey/valkey-glide": "2.4.0"
+  },
+  "peerDependencies": {
+    "genkit": "^0.9.0 || ^1.0.0"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.16",
+    "jest": "^29.7.0",
+    "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
+    "ts-jest": "^29.1.2",
+    "tsup": "^8.0.2",
+    "typescript": "^5.6.3"
+  },
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "require": "./lib/index.js",
+      "import": "./lib/index.mjs",
+      "default": "./lib/index.js"
+    }
+  },
+  "files": [
+    "lib"
+  ],
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  }
+}

--- a/plugins/valkey/src/index.ts
+++ b/plugins/valkey/src/index.ts
@@ -1,0 +1,520 @@
+/**
+ * Copyright 2026 Valkey contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Batch,
+  GlideClient,
+  GlideFt,
+  type Field,
+  type GlideClientConfiguration,
+  type NumericField,
+  type TagField,
+  type TextField,
+  type VectorField,
+} from '@valkey/valkey-glide';
+import { createHash } from 'crypto';
+import {
+  Document,
+  indexerRef,
+  retrieverRef,
+  z,
+  type EmbedderAction,
+  type EmbedderArgument,
+  type EmbedderReference,
+  type Genkit,
+} from 'genkit';
+import { genkitPlugin, type GenkitPlugin } from 'genkit/plugin';
+import { CommonRetrieverOptionsSchema } from 'genkit/retriever';
+
+/** Distance metric for the HNSW index. */
+export type ValkeyDistanceMetric = 'COSINE' | 'L2' | 'IP';
+
+/** Declares a metadata field to index for query-time filtering. */
+export type ValkeyMetadataField = {
+  name: string;
+  type: 'TAG' | 'NUMERIC';
+};
+
+const ValkeyRetrieverOptionsSchema = CommonRetrieverOptionsSchema.extend({
+  k: z.number().max(1000).default(10),
+  /** Raw FT.SEARCH pre-filter expression. Do not pass untrusted user input. */
+  filter: z.string().optional(),
+});
+
+const ValkeyIndexerOptionsSchema = z.null().optional();
+
+type ValkeyPluginParams<
+  EmbedderCustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
+> = {
+  indexName: string;
+  embedder: EmbedderArgument<EmbedderCustomOptions>;
+  embedderOptions?: z.infer<EmbedderCustomOptions>;
+  clientConfig: GlideClientConfiguration;
+  dimension: number;
+  prefix?: string;
+  distanceMetric?: ValkeyDistanceMetric;
+  metadataFields?: ValkeyMetadataField[];
+}[];
+
+/**
+ * Handle returned by valkeyPlugin for managing plugin lifecycle.
+ * Call close() during application shutdown to release connections.
+ */
+export interface ValkeyPluginHandle {
+  /** Close all GlideClient connections owned by this plugin instance. */
+  close(): Promise<void>;
+  /** The GenkitPlugin to pass to Genkit's plugins array. */
+  plugin: GenkitPlugin;
+}
+
+/**
+ * Valkey plugin that provides a Valkey vector store retriever and indexer.
+ * Requires a Valkey instance with the valkey-search module loaded.
+ *
+ * Returns a handle with a `plugin` property (pass to Genkit) and a `close()`
+ * method for connection cleanup. Each call creates an isolated set of clients
+ * scoped to the returned handle.
+ */
+export function valkeyPlugin<EmbedderCustomOptions extends z.ZodTypeAny>(
+  params: ValkeyPluginParams<EmbedderCustomOptions>
+): ValkeyPluginHandle {
+  const clients: GlideClient[] = [];
+
+  const plugin = genkitPlugin('valkey', async (ai: Genkit) => {
+    for (const config of params) {
+      const clientConfig = { ...config.clientConfig };
+      if (!clientConfig.clientName) {
+        clientConfig.clientName = 'genkit_vector_store_client';
+      }
+      const client = await GlideClient.createClient(clientConfig);
+      clients.push(client);
+      const prefix = config.prefix ?? config.indexName;
+      const distanceMetric = config.distanceMetric ?? 'COSINE';
+      const metadataFields = config.metadataFields ?? [];
+
+      await ensureIndex(
+        client,
+        config.indexName,
+        config.dimension,
+        prefix,
+        distanceMetric,
+        metadataFields
+      );
+
+      configureValkeyIndexer(ai, { ...config, prefix, client, metadataFields });
+      configureValkeyRetriever(ai, { ...config, prefix, client });
+    }
+  });
+
+  return {
+    plugin,
+    async close() {
+      const toClose = clients.splice(0);
+      await Promise.all(toClose.map((c) => c.close()));
+    },
+  };
+}
+
+/**
+ * Creates a reference to a Valkey retriever.
+ */
+export const valkeyRetrieverRef = (params: {
+  indexName: string;
+  displayName?: string;
+}) => {
+  return retrieverRef({
+    name: `valkey/${params.indexName}`,
+    info: {
+      label: params.displayName ?? `Valkey - ${params.indexName}`,
+    },
+    configSchema: ValkeyRetrieverOptionsSchema.optional(),
+  });
+};
+
+/**
+ * Creates a reference to a Valkey indexer.
+ */
+export const valkeyIndexerRef = (params: {
+  indexName: string;
+  displayName?: string;
+}) => {
+  return indexerRef({
+    name: `valkey/${params.indexName}`,
+    info: {
+      label: params.displayName ?? `Valkey - ${params.indexName}`,
+    },
+    configSchema: ValkeyIndexerOptionsSchema,
+  });
+};
+
+export default valkeyPlugin;
+
+/** Alias exports matching the naming convention from the narrative. */
+export const valkeyIndexer = valkeyIndexerRef;
+export const valkeyRetriever = valkeyRetrieverRef;
+
+/**
+ * Ensures the FT index exists. If it already exists, the duplicate error is
+ * swallowed silently.
+ */
+async function ensureIndex(
+  client: GlideClient,
+  indexName: string,
+  dimension: number,
+  prefix: string,
+  distanceMetric: ValkeyDistanceMetric,
+  metadataFields: ValkeyMetadataField[]
+): Promise<void> {
+  const vectorField: VectorField = {
+    type: 'VECTOR',
+    name: 'embedding',
+    attributes: {
+      algorithm: 'HNSW',
+      dimensions: dimension,
+      distanceMetric,
+      type: 'FLOAT32',
+    },
+  };
+  const contentField: TextField = { type: 'TEXT', name: '_content' };
+  const metaField: TextField = { type: 'TEXT', name: '_metadata' };
+  const dataTypeField: TextField = { type: 'TEXT', name: '_dataType' };
+
+  const schema: Field[] = [vectorField, contentField, metaField, dataTypeField];
+
+  for (const mf of metadataFields) {
+    if (mf.type === 'NUMERIC') {
+      const f: NumericField = { type: 'NUMERIC', name: mf.name };
+      schema.push(f);
+    } else {
+      const f: TagField = { type: 'TAG', name: mf.name };
+      schema.push(f);
+    }
+  }
+
+  try {
+    await GlideFt.create(client, indexName, schema, {
+      dataType: 'HASH',
+      prefixes: [`${prefix}:`],
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!message.includes('already exists')) {
+      throw err;
+    }
+  }
+}
+
+/**
+ * Configures a Valkey indexer that embeds documents and stores them as Hashes.
+ */
+function configureValkeyIndexer<EmbedderCustomOptions extends z.ZodTypeAny>(
+  ai: Genkit,
+  params: {
+    indexName: string;
+    embedder: EmbedderArgument<EmbedderCustomOptions>;
+    embedderOptions?: z.infer<EmbedderCustomOptions>;
+    prefix: string;
+    client: GlideClient;
+    dimension: number;
+    metadataFields: ValkeyMetadataField[];
+  }
+) {
+  const {
+    indexName,
+    embedder,
+    embedderOptions,
+    prefix,
+    client,
+    dimension,
+    metadataFields,
+  } = params;
+
+  return ai.defineIndexer(
+    {
+      name: `valkey/${indexName}`,
+      configSchema: ValkeyIndexerOptionsSchema,
+    },
+    async (docs) => {
+      if (docs.length === 0) {
+        return;
+      }
+      const embedderAction = await resolveEmbedderAction(ai, embedder);
+      const response = await embedderAction({
+        input: docs.map((doc) => doc.toJSON()),
+        options: embedderOptions,
+      });
+      const allEmbeddings = response.embeddings;
+      if (allEmbeddings.length !== docs.length) {
+        throw new Error(
+          `valkey: embedder returned ${allEmbeddings.length} embeddings for ${docs.length} docs`
+        );
+      }
+
+      for (let i = 0; i < allEmbeddings.length; i++) {
+        if (allEmbeddings[i].embedding.length !== dimension) {
+          throw new Error(
+            `valkey: embedder returned ${allEmbeddings[i].embedding.length}-dim vector, expected ${dimension}`
+          );
+        }
+      }
+
+      const INDEX_BATCH_SIZE = 1000;
+
+      type HSetEntry = { key: string; fields: Record<string, string | Buffer> };
+      const entries: HSetEntry[] = [];
+
+      for (let i = 0; i < docs.length; i++) {
+        const doc = docs[i];
+        const docEmbeddings = [allEmbeddings[i]];
+        const embeddingDocs = doc.getEmbeddingDocuments(docEmbeddings);
+
+        for (let j = 0; j < docEmbeddings.length; j++) {
+          const embedding = docEmbeddings[j].embedding;
+          const embeddingDoc = embeddingDocs[j];
+          const id = stableDocId(embeddingDoc);
+          const embeddingBuffer = Buffer.from(
+            new Float32Array(embedding).buffer
+          );
+
+          const fields: Record<string, string | Buffer> = {
+            embedding: embeddingBuffer,
+            _content: embeddingDoc.data,
+            _metadata: JSON.stringify(embeddingDoc.metadata ?? {}),
+            _dataType: embeddingDoc.dataType ?? '',
+          };
+
+          if (embeddingDoc.metadata) {
+            for (const mf of metadataFields) {
+              const val = (embeddingDoc.metadata as Record<string, unknown>)[
+                mf.name
+              ];
+              if (val !== undefined && val !== null) {
+                if (mf.type === 'NUMERIC') {
+                  if (typeof val !== 'number') {
+                    throw new Error(
+                      `valkey: NUMERIC metadata field '${mf.name}' received non-number value: ${typeof val}`
+                    );
+                  }
+                  fields[mf.name] = val.toString();
+                } else {
+                  fields[mf.name] = String(val);
+                }
+              }
+            }
+          }
+
+          entries.push({ key: `${prefix}:${id}`, fields });
+        }
+      }
+
+      for (let start = 0; start < entries.length; start += INDEX_BATCH_SIZE) {
+        const chunk = entries.slice(start, start + INDEX_BATCH_SIZE);
+        const batch = new Batch(false);
+        for (const entry of chunk) {
+          batch.hset(entry.key, entry.fields);
+        }
+        await client.exec(batch, true);
+      }
+    }
+  );
+}
+
+/**
+ * Configures a Valkey retriever that performs KNN vector search.
+ */
+function configureValkeyRetriever<EmbedderCustomOptions extends z.ZodTypeAny>(
+  ai: Genkit,
+  params: {
+    indexName: string;
+    embedder: EmbedderArgument<EmbedderCustomOptions>;
+    embedderOptions?: z.infer<EmbedderCustomOptions>;
+    prefix: string;
+    client: GlideClient;
+  }
+) {
+  const { indexName, embedder, embedderOptions, client } = params;
+
+  return ai.defineRetriever(
+    {
+      name: `valkey/${indexName}`,
+      configSchema: ValkeyRetrieverOptionsSchema.optional(),
+    },
+    async (content, options) => {
+      const queryEmbeddings = await ai.embed({
+        embedder,
+        content,
+        options: embedderOptions,
+      });
+
+      if (!queryEmbeddings.length) {
+        throw new Error('valkey: embedder returned no embeddings for query');
+      }
+      const queryVector = queryEmbeddings[0].embedding;
+      const queryBuffer = Buffer.from(new Float32Array(queryVector).buffer);
+      const k = options?.k ?? 10;
+      const filter = options?.filter;
+
+      if (filter !== undefined) {
+        validateFilterExpression(filter);
+      }
+
+      const knnQuery = filter
+        ? `(${filter})=>[KNN $k @embedding $query_vec]`
+        : '*=>[KNN $k @embedding $query_vec]';
+
+      const result = await GlideFt.search(client, indexName, knnQuery, {
+        params: [
+          { key: 'k', value: k.toString() },
+          { key: 'query_vec', value: queryBuffer },
+        ],
+        returnFields: [
+          { fieldIdentifier: '_content' },
+          { fieldIdentifier: '_metadata' },
+          { fieldIdentifier: '_dataType' },
+          { fieldIdentifier: '__embedding_score' },
+        ],
+      });
+
+      const [, records] = result;
+
+      const documents = records.map((record) => {
+        const fields = record.value;
+        let contentValue = '';
+        let metadataValue = '{}';
+        let dataTypeValue = '';
+
+        for (const field of fields) {
+          const fieldKey =
+            field.key instanceof Buffer
+              ? field.key.toString()
+              : String(field.key);
+          const fieldVal =
+            field.value instanceof Buffer
+              ? field.value.toString()
+              : String(field.value);
+
+          switch (fieldKey) {
+            case '_content':
+              contentValue = fieldVal;
+              break;
+            case '_metadata':
+              metadataValue = fieldVal;
+              break;
+            case '_dataType':
+              dataTypeValue = fieldVal;
+              break;
+          }
+        }
+
+        const metadata = safeJsonParse(metadataValue);
+        const effectiveDataType = dataTypeValue || 'text';
+        return Document.fromData(contentValue, effectiveDataType, metadata);
+      });
+
+      return { documents };
+    }
+  );
+}
+
+function safeJsonParse(value: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, unknown>;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Produces a deterministic document ID using a canonical serialization format
+ * ({data, dataType, metadata} with sorted keys) that matches the Go and Python
+ * implementations for cross-language interop.
+ */
+/** @internal */
+export function stableDocId(doc: {
+  data: string;
+  metadata?: unknown;
+  dataType?: string;
+}): string {
+  const canonical = {
+    data: doc.data,
+    dataType: doc.dataType ?? 'text',
+    metadata: doc.metadata ?? null,
+  };
+  const sortedStringify = (v: unknown): string => {
+    if (typeof v !== 'object' || v === null) return JSON.stringify(v);
+    if (Array.isArray(v)) return '[' + v.map(sortedStringify).join(',') + ']';
+    return (
+      '{' +
+      Object.keys(v as object)
+        .sort()
+        .map(
+          (k) =>
+            JSON.stringify(k) +
+            ':' +
+            sortedStringify((v as Record<string, unknown>)[k])
+        )
+        .join(',') +
+      '}'
+    );
+  };
+  return createHash('md5').update(sortedStringify(canonical)).digest('hex');
+}
+
+const FILTER_DISALLOWED_PATTERN = /[;|`$\\]|=>/;
+const MAX_FILTER_LENGTH = 2048;
+
+/**
+ * Validates a filter expression to prevent query injection.
+ * Throws if the expression contains characters that could alter query semantics.
+ */
+/** @internal */
+export function validateFilterExpression(filter: string): void {
+  if (filter.length > MAX_FILTER_LENGTH) {
+    throw new Error('valkey: filter expression too long');
+  }
+  if (FILTER_DISALLOWED_PATTERN.test(filter)) {
+    throw new Error(
+      'valkey: filter expression contains disallowed characters. ' +
+        'Do not pass untrusted user input as a filter.'
+    );
+  }
+}
+
+/**
+ * Resolves an EmbedderArgument to an EmbedderAction.
+ */
+async function resolveEmbedderAction<CustomOptions extends z.ZodTypeAny>(
+  ai: Genkit,
+  embedder: EmbedderArgument<CustomOptions>
+): Promise<EmbedderAction<CustomOptions>> {
+  if (typeof embedder === 'string') {
+    return (await ai.registry.lookupAction(
+      `/embedder/${embedder}`
+    )) as EmbedderAction<CustomOptions>;
+  } else if (Object.hasOwnProperty.call(embedder, '__action')) {
+    return embedder as EmbedderAction<CustomOptions>;
+  } else if (Object.hasOwnProperty.call(embedder, 'name')) {
+    const ref = embedder as EmbedderReference<CustomOptions>;
+    return (await ai.registry.lookupAction(
+      `/embedder/${ref.name}`
+    )) as EmbedderAction<CustomOptions>;
+  }
+  throw new Error(`valkey: failed to resolve embedder`);
+}

--- a/plugins/valkey/test/index.test.ts
+++ b/plugins/valkey/test/index.test.ts
@@ -1,0 +1,591 @@
+/**
+ * Copyright 2026 Valkey contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import type { EmbedderArgument, Genkit } from 'genkit';
+import { z } from 'genkit';
+import { Document } from 'genkit/retriever';
+
+// Mock @valkey/valkey-glide
+const mockHset = jest.fn<any>().mockResolvedValue(1);
+const mockBatchHset = jest.fn<any>().mockReturnValue(undefined);
+const mockExec = jest.fn<any>().mockResolvedValue([]);
+const mockClient = { hset: mockHset, exec: mockExec };
+
+const mockGlideFtCreate = jest.fn<any>().mockResolvedValue('OK');
+const mockGlideFtSearch = jest.fn<any>();
+
+jest.mock('@valkey/valkey-glide', () => ({
+  GlideClient: {
+    createClient: jest.fn<any>().mockResolvedValue(mockClient),
+  },
+  GlideFt: {
+    create: (...args: unknown[]) => mockGlideFtCreate(...args),
+    search: (...args: unknown[]) => mockGlideFtSearch(...args),
+  },
+  Batch: jest.fn<any>().mockImplementation(() => {
+    const instance = {
+      hset: (...args: unknown[]) => {
+        mockBatchHset(...args);
+        return instance;
+      },
+    };
+    return instance;
+  }),
+}));
+
+// Import after mocks are set up
+import {
+  stableDocId,
+  validateFilterExpression,
+  valkeyIndexerRef,
+  valkeyPlugin,
+  valkeyRetrieverRef,
+} from '../src';
+
+// Mock Genkit instance
+const mockEmbed = jest.fn<any>();
+const mockEmbedderAction = jest.fn<any>();
+const mockLookupAction = jest.fn<any>().mockResolvedValue(mockEmbedderAction);
+const mockDefineRetriever = jest.fn<any>((config: any, handler: any) => ({
+  config,
+  retrieve: handler,
+}));
+const mockDefineIndexer = jest.fn<any>((config: any, handler: any) => ({
+  config,
+  index: handler,
+}));
+
+const mockGenkit: Genkit = {
+  embed: mockEmbed,
+  defineRetriever: mockDefineRetriever,
+  defineIndexer: mockDefineIndexer,
+  registry: {
+    lookupAction: mockLookupAction,
+  },
+} as unknown as Genkit;
+
+const mockEmbedder: EmbedderArgument<z.ZodTypeAny> = {
+  name: 'mock-embedder',
+  type: 'embedder',
+  configSchema: z.object({}),
+} as any;
+
+describe('valkeyPlugin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGlideFtCreate.mockResolvedValue('OK');
+  });
+
+  test('should create index on initialization', async () => {
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'test-index',
+        embedder: mockEmbedder,
+        dimension: 768,
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await pluginInstance.initializer();
+
+    expect(mockGlideFtCreate).toHaveBeenCalledWith(
+      mockClient,
+      'test-index',
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'VECTOR',
+          name: 'embedding',
+          attributes: expect.objectContaining({
+            algorithm: 'HNSW',
+            dimensions: 768,
+            distanceMetric: 'COSINE',
+            type: 'FLOAT32',
+          }),
+        }),
+        expect.objectContaining({ type: 'TEXT', name: '_content' }),
+        expect.objectContaining({ type: 'TEXT', name: '_metadata' }),
+        expect.objectContaining({ type: 'TEXT', name: '_dataType' }),
+      ]),
+      expect.objectContaining({
+        dataType: 'HASH',
+        prefixes: ['test-index:'],
+      })
+    );
+  });
+
+  test('should handle duplicate index error gracefully', async () => {
+    mockGlideFtCreate.mockRejectedValue(new Error('Index already exists'));
+
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'existing-index',
+        embedder: mockEmbedder,
+        dimension: 768,
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await expect(pluginInstance.initializer()).resolves.not.toThrow();
+  });
+
+  test('should propagate non-duplicate-index errors', async () => {
+    mockGlideFtCreate.mockRejectedValue(new Error('Connection refused'));
+
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'fail-index',
+        embedder: mockEmbedder,
+        dimension: 768,
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await expect(pluginInstance.initializer()).rejects.toThrow(
+      'Connection refused'
+    );
+  });
+
+  test('should register both indexer and retriever', async () => {
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'test-index',
+        embedder: mockEmbedder,
+        dimension: 768,
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await pluginInstance.initializer();
+
+    expect(mockDefineIndexer).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'valkey/test-index' }),
+      expect.any(Function)
+    );
+    expect(mockDefineRetriever).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'valkey/test-index' }),
+      expect.any(Function)
+    );
+  });
+
+  test('should use custom prefix when provided', async () => {
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'test-index',
+        embedder: mockEmbedder,
+        dimension: 768,
+        prefix: 'custom',
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await pluginInstance.initializer();
+
+    expect(mockGlideFtCreate).toHaveBeenCalledWith(
+      mockClient,
+      'test-index',
+      expect.any(Array),
+      expect.objectContaining({
+        prefixes: ['custom:'],
+      })
+    );
+  });
+});
+
+describe('valkeyIndexer', () => {
+  let indexerHandler: (docs: Document[]) => Promise<void>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockGlideFtCreate.mockResolvedValue('OK');
+
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'test-index',
+        embedder: mockEmbedder,
+        dimension: 3,
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await pluginInstance.initializer();
+
+    indexerHandler = mockDefineIndexer.mock.calls[0][1] as any;
+  });
+
+  test('should embed documents and store as hashes', async () => {
+    mockEmbedderAction.mockResolvedValue({
+      embeddings: [{ embedding: [0.1, 0.2, 0.3] }],
+    });
+
+    const doc = new Document({
+      content: [{ text: 'Hello world' }],
+      metadata: { source: 'test' },
+    });
+
+    await indexerHandler([doc]);
+
+    expect(mockEmbedderAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.any(Array),
+      })
+    );
+    expect(mockBatchHset).toHaveBeenCalledWith(
+      expect.stringMatching(/^test-index:/),
+      expect.objectContaining({
+        embedding: expect.anything(),
+        _content: expect.any(String),
+        _metadata: expect.any(String),
+        _dataType: expect.any(String),
+      })
+    );
+    expect(mockExec).toHaveBeenCalledTimes(1);
+  });
+
+  test('should convert embedding to Float32 buffer', async () => {
+    const embedding = [1.0, 2.0, 3.0];
+    mockEmbedderAction.mockResolvedValue({
+      embeddings: [{ embedding }],
+    });
+
+    const doc = new Document({ content: [{ text: 'test' }] });
+    await indexerHandler([doc]);
+
+    const hsetCall = mockBatchHset.mock.calls[0] as unknown[];
+    const fields = hsetCall[1] as Record<string, any>;
+    const embeddingValue = fields['embedding'];
+
+    expect(embeddingValue).toBeDefined();
+    expect(embeddingValue).toBeInstanceOf(Buffer);
+
+    const expected = Buffer.from(new Float32Array(embedding).buffer);
+    expect(embeddingValue).toEqual(expected);
+  });
+
+  test('should serialize metadata as JSON', async () => {
+    mockEmbedderAction.mockResolvedValue({
+      embeddings: [{ embedding: [0.1, 0.2, 0.3] }],
+    });
+
+    const metadata = { page: 1, source: 'docs', nested: { key: 'value' } };
+    const doc = new Document({
+      content: [{ text: 'test' }],
+      metadata,
+    });
+
+    await indexerHandler([doc]);
+
+    const hsetCall = mockBatchHset.mock.calls[0] as unknown[];
+    const fields = hsetCall[1] as Record<string, any>;
+    const metadataValue = fields['_metadata'];
+
+    expect(metadataValue).toBeDefined();
+    expect(JSON.parse(metadataValue)).toEqual(metadata);
+  });
+
+  test('should handle multiple documents', async () => {
+    mockEmbedderAction.mockResolvedValue({
+      embeddings: [
+        { embedding: [0.1, 0.2, 0.3] },
+        { embedding: [0.4, 0.5, 0.6] },
+        { embedding: [0.7, 0.8, 0.9] },
+      ],
+    });
+
+    const docs = [
+      new Document({ content: [{ text: 'doc1' }] }),
+      new Document({ content: [{ text: 'doc2' }] }),
+      new Document({ content: [{ text: 'doc3' }] }),
+    ];
+
+    await indexerHandler(docs);
+
+    expect(mockEmbedderAction).toHaveBeenCalledTimes(1);
+    expect(mockBatchHset).toHaveBeenCalledTimes(3);
+    expect(mockExec).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('valkeyRetriever', () => {
+  let retrieverHandler: (content: any, options: any) => Promise<any>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockGlideFtCreate.mockResolvedValue('OK');
+
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'test-index',
+        embedder: mockEmbedder,
+        dimension: 3,
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await pluginInstance.initializer();
+
+    retrieverHandler = mockDefineRetriever.mock.calls[0][1] as any;
+  });
+
+  test('should embed query and call GlideFt.search with KNN', async () => {
+    mockEmbed.mockResolvedValue([{ embedding: [0.1, 0.2, 0.3] }]);
+    mockGlideFtSearch.mockResolvedValue([0, []]);
+
+    await retrieverHandler('What is Valkey?', { k: 5 });
+
+    expect(mockEmbed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embedder: mockEmbedder,
+        content: 'What is Valkey?',
+      })
+    );
+    expect(mockGlideFtSearch).toHaveBeenCalledWith(
+      mockClient,
+      'test-index',
+      '*=>[KNN $k @embedding $query_vec]',
+      expect.objectContaining({
+        params: expect.arrayContaining([
+          expect.objectContaining({ key: 'k', value: '5' }),
+          expect.objectContaining({ key: 'query_vec' }),
+        ]),
+        returnFields: expect.arrayContaining([
+          expect.objectContaining({ fieldIdentifier: '_content' }),
+          expect.objectContaining({ fieldIdentifier: '_metadata' }),
+          expect.objectContaining({ fieldIdentifier: '_dataType' }),
+        ]),
+      })
+    );
+  });
+
+  test('should parse search results into Document objects', async () => {
+    mockEmbed.mockResolvedValue([{ embedding: [0.1, 0.2, 0.3] }]);
+    mockGlideFtSearch.mockResolvedValue([
+      2,
+      [
+        {
+          key: 'test-index:abc123',
+          value: [
+            { key: '_content', value: 'Valkey is a key-value store.' },
+            { key: '_metadata', value: '{"source":"docs"}' },
+            { key: '_dataType', value: 'text' },
+            { key: '__embedding_score', value: '0.95' },
+          ],
+        },
+        {
+          key: 'test-index:def456',
+          value: [
+            { key: '_content', value: 'ElastiCache supports Valkey.' },
+            { key: '_metadata', value: '{}' },
+            { key: '_dataType', value: '' },
+            { key: '__embedding_score', value: '0.85' },
+          ],
+        },
+      ],
+    ]);
+
+    const result = await retrieverHandler('What is Valkey?', { k: 2 });
+
+    expect(result.documents).toHaveLength(2);
+    expect(result.documents[0]).toBeInstanceOf(Document);
+    expect(result.documents[1]).toBeInstanceOf(Document);
+  });
+
+  test('should handle Buffer values in search results', async () => {
+    mockEmbed.mockResolvedValue([{ embedding: [0.1, 0.2, 0.3] }]);
+    mockGlideFtSearch.mockResolvedValue([
+      1,
+      [
+        {
+          key: Buffer.from('test-index:abc123'),
+          value: [
+            { key: Buffer.from('_content'), value: Buffer.from('Hello') },
+            { key: Buffer.from('_metadata'), value: Buffer.from('{}') },
+            { key: Buffer.from('_dataType'), value: Buffer.from('text') },
+          ],
+        },
+      ],
+    ]);
+
+    const result = await retrieverHandler('query', { k: 1 });
+
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0]).toBeInstanceOf(Document);
+  });
+
+  test('should default k to 10 when not specified', async () => {
+    mockEmbed.mockResolvedValue([{ embedding: [0.1, 0.2, 0.3] }]);
+    mockGlideFtSearch.mockResolvedValue([0, []]);
+
+    await retrieverHandler('query', {});
+
+    expect(mockGlideFtSearch).toHaveBeenCalledWith(
+      mockClient,
+      'test-index',
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.arrayContaining([
+          expect.objectContaining({ key: 'k', value: '10' }),
+        ]),
+      })
+    );
+  });
+
+  test('should handle empty search results', async () => {
+    mockEmbed.mockResolvedValue([{ embedding: [0.1, 0.2, 0.3] }]);
+    mockGlideFtSearch.mockResolvedValue([0, []]);
+
+    const result = await retrieverHandler('no results query', { k: 5 });
+
+    expect(result.documents).toHaveLength(0);
+  });
+
+  test('should handle invalid metadata JSON gracefully', async () => {
+    mockEmbed.mockResolvedValue([{ embedding: [0.1, 0.2, 0.3] }]);
+    mockGlideFtSearch.mockResolvedValue([
+      1,
+      [
+        {
+          key: 'test-index:abc',
+          value: [
+            { key: '_content', value: 'content' },
+            { key: '_metadata', value: 'not-valid-json' },
+            { key: '_dataType', value: '' },
+          ],
+        },
+      ],
+    ]);
+
+    const result = await retrieverHandler('query', { k: 1 });
+
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0]).toBeInstanceOf(Document);
+  });
+});
+
+describe('valkeyRetrieverRef', () => {
+  test('should create a retriever reference with correct name', () => {
+    const ref = valkeyRetrieverRef({ indexName: 'my-docs' });
+    expect(ref.name).toBe('valkey/my-docs');
+  });
+
+  test('should use custom display name', () => {
+    const ref = valkeyRetrieverRef({
+      indexName: 'my-docs',
+      displayName: 'My Docs Retriever',
+    });
+    expect(ref.info?.label).toBe('My Docs Retriever');
+  });
+
+  test('should use default display name', () => {
+    const ref = valkeyRetrieverRef({ indexName: 'my-docs' });
+    expect(ref.info?.label).toBe('Valkey - my-docs');
+  });
+});
+
+describe('valkeyIndexerRef', () => {
+  test('should create an indexer reference with correct name', () => {
+    const ref = valkeyIndexerRef({ indexName: 'my-docs' });
+    expect(ref.name).toBe('valkey/my-docs');
+  });
+
+  test('should use custom display name', () => {
+    const ref = valkeyIndexerRef({
+      indexName: 'my-docs',
+      displayName: 'My Docs Indexer',
+    });
+    expect(ref.info?.label).toBe('My Docs Indexer');
+  });
+});
+
+describe('stableDocId', () => {
+  test('same doc with nested metadata in different key orders produces same ID', () => {
+    const id1 = stableDocId({
+      data: 'hello',
+      metadata: { a: 1, b: 2 },
+      dataType: 'text',
+    });
+    const id2 = stableDocId({
+      data: 'hello',
+      metadata: { b: 2, a: 1 },
+      dataType: 'text',
+    });
+    expect(id1).toBe(id2);
+  });
+
+  test('docs with different metadata produce different IDs', () => {
+    const id1 = stableDocId({
+      data: 'hello',
+      metadata: { a: 1 },
+      dataType: 'text',
+    });
+    const id2 = stableDocId({
+      data: 'hello',
+      metadata: { a: 2 },
+      dataType: 'text',
+    });
+    expect(id1).not.toBe(id2);
+  });
+
+  test('metadata content is included in hash (not dropped)', () => {
+    const idWithMeta = stableDocId({
+      data: 'hello',
+      metadata: { key: 'value' },
+      dataType: 'text',
+    });
+    const idNoMeta = stableDocId({
+      data: 'hello',
+      metadata: {},
+      dataType: 'text',
+    });
+    expect(idWithMeta).not.toBe(idNoMeta);
+  });
+
+  test('produces stable hash for known input', () => {
+    const id = stableDocId({ data: 'hello', dataType: 'text' });
+    expect(id).toBe('3c04c6b9f04e5e522404b4c567ad09b0');
+  });
+});
+
+describe('validateFilterExpression', () => {
+  test('valid filter expressions do not throw', () => {
+    expect(() => validateFilterExpression('@price:[100 200]')).not.toThrow();
+    expect(() => validateFilterExpression('@tag:{foo}')).not.toThrow();
+    expect(() => validateFilterExpression('*')).not.toThrow();
+    expect(() => validateFilterExpression('')).not.toThrow();
+  });
+
+  test.each([';', '|', '`', '$', '\\'])('blocks disallowed char %s', (char) => {
+    expect(() =>
+      validateFilterExpression(`@field:[0 10]${char}inject`)
+    ).toThrow('disallowed characters');
+  });
+
+  test('blocks => KNN query injection sequence', () => {
+    expect(() =>
+      validateFilterExpression('@tag:{x})=>[KNN 99999 @embedding $query_vec]')
+    ).toThrow('disallowed characters');
+    expect(() => validateFilterExpression('foo=>bar')).toThrow(
+      'disallowed characters'
+    );
+  });
+});

--- a/plugins/valkey/tsconfig.json
+++ b/plugins/valkey/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/plugins/valkey/tsup.config.ts
+++ b/plugins/valkey/tsup.config.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2026 Valkey contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig, Options } from 'tsup';
+import { defaultOptions } from '../../tsup.common';
+
+export default defineConfig({
+  ...(defaultOptions as Options),
+});


### PR DESCRIPTION
_Before you submit a pull request, please make sure you have read and understood the [contribution guidelines](https://github.com/BloomLabsInc/genkit-plugins/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BloomLabsInc/genkit-plugins/blob/main/CODE_OF_CONDUCT.md)._

**This pull request is related to:**

- [ ] A bug
- [x] A new feature
- [ ] Documentation
- [ ] Other (please specify)

**I have checked the following:**

- [x] I have read and understood the [contribution guidelines](https://github.com/BloomLabsInc/genkit-plugins/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BloomLabsInc/genkit-plugins/blob/main/CODE_OF_CONDUCT.md);
- [x] I have added new tests (for bug fixes/features);
- [x] I have added/updated the documentation (for bug fixes / features).

**Description:**

Adds `genkitx-valkey`, a new plugin that provides Genkit `Indexer` and `Retriever` implementations backed by Valkey with the valkey-search module.

The plugin uses `@valkey/valkey-glide` (pinned at 2.4.0) to connect to a standalone Valkey instance. On initialization it creates an HNSW vector index via `FT.CREATE`, then exposes:

- An indexer that embeds documents (via any Genkit embedder), serializes them as Float32 buffers, and writes them as Valkey hashes in batches.
- A retriever that embeds the query and runs a KNN search with `FT.SEARCH`, returning parsed `Document` objects.

Other details:
- Deterministic document IDs via MD5 of a canonical JSON serialization (sorted keys).
- Optional metadata field indexing (TAG/NUMERIC) for query-time pre-filtering.
- Filter expression validation to block injection of `=>`, `;`, `|`, `$`, etc.
- `close()` handle for connection cleanup on shutdown.

**Files added:**

- `plugins/valkey/src/index.ts` — plugin implementation (indexer, retriever, index creation, helpers)
- `plugins/valkey/test/index.test.ts` — 31 unit tests covering initialization, indexing, retrieval, refs, stable IDs, and filter validation (84% line coverage)
- `plugins/valkey/package.json` — package config, deps, scripts
- `plugins/valkey/README.md` — usage docs, config table, prerequisites
- `plugins/valkey/tsconfig.json`, `tsup.config.ts`, `jest.config.js` — build/test config
- `plugins/valkey/.gitignore`, `.npmignore`, `LICENSE`
- `package-lock.json` — updated with `@valkey/valkey-glide` and its platform-specific binaries

**Tests:**

31 unit tests in `plugins/valkey/test/index.test.ts` using Jest with mocked `@valkey/valkey-glide`. Covers:
- Plugin init (index creation, duplicate handling, error propagation)
- Indexer (embedding, Float32 buffer conversion, metadata serialization, batching)
- Retriever (KNN query construction, result parsing, Buffer handling, defaults, empty results, invalid JSON)
- Ref helpers (name, display name)
- `stableDocId` (determinism, key ordering, collision avoidance)
- `validateFilterExpression` (allowed patterns, blocked chars, injection sequences)

Run with `npm run test` from the plugin directory or `npm run test` from root.

**Related issues:**

N/A
