### PR TITLE
Add bugs URL to package.json

### DIFF
--- a/plugins/openai/package.json
+++ b/plugins/openai/package.json
@@ -22,6 +22,9 @@
     "url": "git+https://github.com/BloomLabsInc/genkit-plugins.git",
     "directory": "plugins/openai"
   },
+  "bugs": {
+    "url": "https://github.com/BloomLabsInc/genkit-plugins/issues"
+  },
   "author": "BloomLabsInc",
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This PR adds missing npm issue-tracker metadata for the `genkitx-openai` package.

Changes:
- Add `bugs.url` pointing to this repository's GitHub issues page.
- No runtime code changes.

This helps npm users find the correct place to report package issues.