### PR TITLE
Add bugs metadata for genkitx-openai

### DIFF
--- a/plugins/openai/package.json
+++ b/plugins/openai/package.json
@@ -22,6 +22,9 @@
     "url": "git+https://github.com/BloomLabsInc/genkit-plugins.git",
     "directory": "plugins/openai"
   },
+  "bugs": {
+    "url": "https://github.com/BloomLabsInc/genkit-plugins/issues"
+  },
   "author": "BloomLabsInc",
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add the missing `bugs` metadata to the `genkitx-openai` package manifest.

## Verification
- `python3 -m json.tool plugins/openai/package.json`
- `npm pack --dry-run --json` (from `plugins/openai`)

Bounty: https://github.com/charles-openclaw/charles-microbounties/issues/1326