### PR TITLE
feat: add Groq models

### DIFF
--- a/plugins/groq/src/groq_models.ts
+++ b/plugins/groq/src/groq_models.ts
@@ -265,6 +265,91 @@ export const deepseekR1DistillLlamax70b = modelRef({
   version: 'deepseek-r1-distill-llama-70b',
 });
 
+export const gptOssx20b = modelRef({
+  name: 'groq/openai/gpt-oss-20b',
+  info: {
+    versions: ['openai/gpt-oss-20b'],
+    label: 'GPT OSS 20B',
+    supports: {
+      multiturn: true,
+      tools: true, // Could be true but not recommended
+      media: false,
+      systemRole: true,
+      output: ['text', 'json'],
+    },
+  },
+  configSchema: GroqConfigSchema,
+  version: 'openai/gpt-oss-20b',
+});
+
+export const gptOssSafeguardx20b = modelRef({
+  name: 'groq/openai/gpt-oss-safeguard-20b',
+  info: {
+    versions: ['openai/gpt-oss-safeguard-20b'],
+    label: 'Safety GPT OSS 20B',
+    supports: {
+      multiturn: true,
+      tools: true, // Could be true but not recommended
+      media: false,
+      systemRole: true,
+      output: ['text', 'json'],
+    },
+  },
+  configSchema: GroqConfigSchema,
+  version: 'openai/gpt-oss-safeguard-20b',
+});
+
+export const gptOssx120b = modelRef({
+  name: 'groq/openai/gpt-oss-120b',
+  info: {
+    versions: ['openai/gpt-oss-120b'],
+    label: 'GPT OSS 120B',
+    supports: {
+      multiturn: true,
+      tools: true, // Could be true but not recommended
+      media: false,
+      systemRole: true,
+      output: ['text', 'json'],
+    },
+  },
+  configSchema: GroqConfigSchema,
+  version: 'openai/gpt-oss-120b',
+});
+
+export const qwen36x27b = modelRef({
+  name: 'groq/qwen/qwen3.6-27b',
+  info: {
+    versions: ['qwen/qwen3.6-27b'],
+    label: 'Qwen 3.6 27B',
+    supports: {
+      multiturn: true,
+      tools: true, // Could be true but not recommended
+      media: false, // supports image input
+      systemRole: true,
+      output: ['text', 'json'],
+    },
+  },
+  configSchema: GroqConfigSchema,
+  version: 'qwen/qwen3.6-27b',
+});
+
+export const qwen3x32b = modelRef({
+  name: 'groq/qwen/qwen3-32b',
+  info: {
+    versions: ['qwen/qwen3-32b'],
+    label: 'Qwen 3 32B',
+    supports: {
+      multiturn: true,
+      tools: true, // Could be true but not recommended
+      media: false,
+      systemRole: true,
+      output: ['text', 'json'],
+    },
+  },
+  configSchema: GroqConfigSchema,
+  version: 'qwen/qwen3-32b',
+});
+
 export const SUPPORTED_GROQ_MODELS = {
   'llama-3-8b': llama3x8b,
   'llama-3-70b': llama3x70b,
@@ -278,6 +363,11 @@ export const SUPPORTED_GROQ_MODELS = {
   'qwen-qwq-32b': qwenqwqx32b,
   'deepseek-r1-distill-llama-70b': deepseekR1DistillLlamax70b,
   'allam-2-7b': allam2x7b,
+  'openai/gpt-oss-20b': gptOssx20b,
+  'openai/gpt-oss-safeguard-20b': gptOssSafeguardx20b,
+  'openai/gpt-oss-120b': gptOssx120b,
+  'qwen/qwen3.6-27b': qwen36x27b,
+  'qwen/qwen3-32b': qwen3x32b,
 };
 
 /**

--- a/plugins/groq/src/index.ts
+++ b/plugins/groq/src/index.ts
@@ -30,6 +30,11 @@ import {
   qwenqwqx32b,
   allam2x7b,
   deepseekR1DistillLlamax70b,
+  gptOssx20b,
+  gptOssx120b,
+  gptOssSafeguardx20b,
+  qwen36x27b,
+  qwen3x32b,
   SUPPORTED_GROQ_MODELS,
 } from './groq_models';
 import { Genkit } from 'genkit';
@@ -49,6 +54,11 @@ export {
   qwenqwqx32b,
   allam2x7b,
   deepseekR1DistillLlamax70b,
+  gptOssx20b,
+  gptOssx120b,
+  gptOssSafeguardx20b,
+  qwen36x27b,
+  qwen3x32b,
 };
 
 // Define the PluginOptions interface for customization of the Groq plugin.


### PR DESCRIPTION
**This pull request is related to:**

- [ ] A bug
- [ ] A new feature
- [ ] Documentation
- [x] Other (New models in genkitx-groq)

**I have checked the following:**

- [x] I have read and understood the [contribution guidelines](https://github.com/BloomLabsInc/genkit-plugins/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BloomLabsInc/genkit-plugins/blob/main/CODE_OF_CONDUCT.md);
- [x] I have added new tests (for bug fixes/features);
- [x] I have added/updated the documentation (for bug fixes / features).

**Description:**
Based on the information at [Groq model deprecations](https://console.groq.com/docs/deprecations), I added the latest models suggestions to the genkitx-groq plugin from the models gotten from [groq-models-api](https://console.groq.com/docs/models#get-all-available-models) 

Current | Deprecation | Replacement
-- | -- | --
llama-3-8b | 2026-08-16 | openai/gpt-oss-20b
llama-3-70b | 2026-08-16 | openai/gpt-oss-20b
llama-guard-3-8b | 2025-06-06 | openai/gpt-oss-safeguard-20b
llama-3.3-70b-versatile | 2026-08-16 | openai/gpt-oss-120b or qwen/qwen3.6-27b
llama-3.1-8b-instant | 2026-08-16 | openai/gpt-oss-20b
meta-llama/llama-4-maverick-17b-128e-instruct | 2026-03-09 | openai/gpt-oss-120b
meta-llama/llama-4-scout-17b-16e-instruct | 2026-07-17 | openai/gpt-oss-120b or qwen/qwen3.6-27b
mistral-saba-24b | 2025-07-30 | qwen/qwen3-32b
gemma2-9b | 2025-10-08 | openai/gpt-oss-20b
qwen-qwq-32b | 2025-07-14 | openai/gpt-oss-120b
deepseek-r1-distill-llama-70b | 2025-04-14 | openai/gpt-oss-120b
allam-2-7b | — | No replacement found

**Related issues:**
Please, link the related issues that this pull request will resolve here (if any).
